### PR TITLE
fix(@cerbos/grpc): Add explicit dependency on `long`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6338,6 +6338,7 @@
       "dependencies": {
         "@cerbos/core": "^0.5.0",
         "@grpc/grpc-js": "^1.6.7",
+        "long": "^4.0.0",
         "protobufjs": "^6.11.3"
       },
       "engines": {
@@ -6816,6 +6817,7 @@
       "requires": {
         "@cerbos/core": "^0.5.0",
         "@grpc/grpc-js": "^1.6.7",
+        "long": "^4.0.0",
         "protobufjs": "^6.11.3"
       }
     },

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@cerbos/core": "^0.5.0",
     "@grpc/grpc-js": "^1.6.7",
+    "long": "^4.0.0",
     "protobufjs": "^6.11.3"
   }
 }


### PR DESCRIPTION
This PR fixes `Cannot find module 'long'` from `node_modules/@cerbos/grpc/lib/protobuf/cerbos/svc/v1/svc.js`.