### PR TITLE
docs: Make README links relative to file to fix broken links on npmjs.com

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Make README links relative to file to fix broken links on npmjs.com ([#103](https://github.com/cerbos/cerbos-sdk-javascript/pull/103))
 
 ## [0.5.0] - 2022-06-07
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,11 +2,11 @@
 
 [![npm](https://img.shields.io/npm/v/@cerbos/core?style=flat-square)](https://www.npmjs.com/package/@cerbos/core)
 
-Common types used by the [gRPC](/packages/grpc/README.md) and [HTTP](/packages/http/README.md) client libraries.
+Common types used by the [gRPC](../grpc/README.md) and [HTTP](../http/README.md) client libraries.
 
 ## Further reading
 
-- [API reference](/docs/core.md)
+- [API reference](../../docs/core.md)
 - [Cerbos documentation](https://docs.cerbos.dev)
 
 ## Get help

--- a/packages/grpc/CHANGELOG.md
+++ b/packages/grpc/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Make README links relative to file to fix broken links on npmjs.com ([#103](https://github.com/cerbos/cerbos-sdk-javascript/pull/103))
 
 ## [0.5.1] - 2022-06-07
 

--- a/packages/grpc/README.md
+++ b/packages/grpc/README.md
@@ -35,11 +35,11 @@ await cerbos.isAllowed({
 }); // => true
 ```
 
-For more details, [see the `GRPC` class documentation](/docs/grpc.grpc.md).
+For more details, [see the `GRPC` class documentation](../../docs/grpc.grpc.md).
 
 ## Further reading
 
-- [API reference](/docs/grpc.md)
+- [API reference](../../docs/grpc.md)
 - [Cerbos documentation](https://docs.cerbos.dev)
 
 ## Get help

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Make README links relative to file to fix broken links on npmjs.com ([#103](https://github.com/cerbos/cerbos-sdk-javascript/pull/103))
 
 ## [0.5.0] - 2022-06-07
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -7,7 +7,7 @@ Client library for interacting with the Cerbos policy decision point over HTTP.
 This is primarily intended for use in browsers, and requires `fetch` to be available globally.
 If you're targeting [old browsers](https://caniuse.com/fetch), you'll need to apply [a polyfill](https://www.npmjs.com/package/whatwg-fetch).
 
-You can use it in server-side Node.js applications, but the [gRPC client](/packages/grpc/README.md) might be more appropriate.
+You can use it in server-side Node.js applications, but the [gRPC client](../grpc/README.md) might be more appropriate.
 
 - For Node.js up to 17.4, you'll need [a polyfill](https://www.npmjs.com/package/cross-fetch) to make `fetch` happen.
 - From Node.js 17.5, you can instead enable the [`--experimental-fetch`](https://nodejs.org/dist/latest-v17.x/docs/api/cli.html#--experimental-fetch) option at the command line or via `NODE_OPTIONS`.
@@ -45,11 +45,11 @@ await cerbos.isAllowed({
 }); // => true
 ```
 
-For more details, [see the `HTTP` class documentation](/docs/http.http.md).
+For more details, [see the `HTTP` class documentation](../../docs/http.http.md).
 
 ## Further reading
 
-- [API reference](/docs/http.md)
+- [API reference](../../docs/http.md)
 - [Cerbos documentation](https://docs.cerbos.dev)
 
 ## Get help


### PR DESCRIPTION
npmjs.com erroneously inserts the package directory into README links that are relative to the repository root, so that e.g. `/docs/core.md` links to `/packages/core/docs/core.md`.

I've raised this with npm support but to work around the issue we can change the links to be relative to the current file rather than the repository root.