### PR TITLE
chore(ci): Set output via environment file rather than stdout

### DIFF
--- a/scripts/test-matrix
+++ b/scripts/test-matrix
@@ -54,5 +54,7 @@ matrix = {
   ]
 }
 
-puts "::set-output name=matrix::#{matrix.to_json}"
 puts JSON.pretty_generate(matrix)
+
+output_file = ENV["GITHUB_OUTPUT"]
+File.write output_file, "matrix=#{matrix.to_json}" if output_file


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/