### PR TITLE
chore(ci): Disable conventional commit check for Renovate

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -30,3 +30,4 @@ jobs:
           requireScope: false
           subjectPattern: ^[A-Z].+$
           subjectPatternError: Subject "{subject}" does not start with an uppercase letter
+          validateSingleCommit: true

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,6 +12,7 @@ jobs:
   validate-pull-request-title:
     name: Validate pull request title
     runs-on: ubuntu-latest
+    if: github.actor != "renovate[bot]"
     steps:
       - uses: amannn/action-semantic-pull-request@v5.0.2
         env:


### PR DESCRIPTION
Renovate can't be configured to upper-case the start of a conventional commit message.