### PR TITLE
chore: Remove `docker compose up --wait` one-shot container workaround

### DIFF
--- a/packages/test/servers/docker-compose.yml
+++ b/packages/test/servers/docker-compose.yml
@@ -4,14 +4,6 @@ services:
   certificates:
     image: ruby:3.1-alpine
     entrypoint: /generate-certificates
-    healthcheck:
-      interval: 2s
-      timeout: 1s
-      test:
-        - CMD
-        - test
-        - -f
-        - /healthy
     volumes:
       - type: bind
         source: generate-certificates
@@ -61,7 +53,7 @@ services:
         read_only: true
     depends_on:
       certificates:
-        condition: service_healthy
+        condition: service_completed_successfully
 
   mtls:
     image: traefik:2.6
@@ -90,7 +82,7 @@ services:
         read_only: true
     depends_on:
       certificates:
-        condition: service_healthy
+        condition: service_completed_successfully
 
   mutable:
     extends: plaintext
@@ -103,4 +95,4 @@ services:
         read_only: true
     depends_on:
       certificates:
-        condition: service_healthy
+        condition: service_completed_successfully

--- a/packages/test/servers/generate-certificates
+++ b/packages/test/servers/generate-certificates
@@ -54,7 +54,3 @@ end
 
 generate_self_signed_certificate "server"
 generate_self_signed_certificate "client"
-
-# `docker compose up --wait` hangs if containers have exited (https://github.com/docker/compose/issues/9273)
-File.write "/healthy", ""
-exec "sleep", "infinity"


### PR DESCRIPTION
https://github.com/docker/compose/pull/9572