### PR TITLE
docs: Add principal and resource `attributes` fields to examples

### DIFF
--- a/docs/core.client.checkresource.md
+++ b/docs/core.client.checkresource.md
@@ -27,8 +27,16 @@ Promise&lt;[CheckResourcesResult](./core.checkresourcesresult.md)<!-- -->&gt;
 
 ```typescript
 const decision = await cerbos.checkResource({
-  principal: { id: "user@example.com", roles: ["USER"] },
-  resource: { kind: "document", id: "1" },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
+  resource: {
+    kind: "document",
+    id: "1",
+    attributes: { owner: "user@example.com" },
+  },
   actions: ["view", "edit"],
 });
 

--- a/docs/core.client.checkresources.md
+++ b/docs/core.client.checkresources.md
@@ -27,14 +27,26 @@ Promise&lt;[CheckResourcesResponse](./core.checkresourcesresponse.md)<!-- -->&gt
 
 ```typescript
 const decision = await cerbos.checkResources({
-  principal: { id: "user@example.com", roles: ["USER"] },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
   resources: [
     {
-      resource: { kind: "document", id: "1" },
+      resource: {
+        kind: "document",
+        id: "1",
+        attributes: { owner: "user@example.com" },
+      },
       actions: ["view", "edit"],
     },
     {
-      resource: { kind: "image", id: "1" },
+      resource: {
+        kind: "image",
+        id: "1",
+        attributes: { owner: "user@example.com" },
+      },
       actions: ["delete"],
     },
   ],

--- a/docs/core.client.isallowed.md
+++ b/docs/core.client.isallowed.md
@@ -27,8 +27,16 @@ Promise&lt;boolean&gt;
 
 ```typescript
 await cerbos.isAllowed({
-  principal: { id: "user@example.com", roles: ["USER"] },
-  resource: { kind: "document", id: "1" },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
+  resource: {
+    kind: "document",
+    id: "1",
+    attributes: { owner: "user@example.com" },
+  },
   action: "view",
 }); // => true
 ```

--- a/docs/core.client.planresources.md
+++ b/docs/core.client.planresources.md
@@ -27,7 +27,11 @@ Promise&lt;[PlanResourcesResponse](./core.planresourcesresponse.md)<!-- -->&gt;
 
 ```typescript
 const plan = await cerbos.planResources({
-  principal: { id: "user@example.com", roles: ["USER"] },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
   resource: { kind: "document" },
 });
 ```

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Document principal and resource `attributes` fields in examples ([#358](https://github.com/cerbos/cerbos-sdk-javascript/pull/358))
 
 ## [0.8.0] - 2022-09-08
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -194,8 +194,16 @@ export abstract class Client {
    * @example
    * ```typescript
    * const decision = await cerbos.checkResource({
-   *   principal: { id: "user@example.com", roles: ["USER"] },
-   *   resource: { kind: "document", id: "1" },
+   *   principal: {
+   *     id: "user@example.com",
+   *     roles: ["USER"],
+   *     attributes: { tier: "PREMIUM" },
+   *   },
+   *   resource: {
+   *     kind: "document",
+   *     id: "1",
+   *     attributes: { owner: "user@example.com" },
+   *   },
    *   actions: ["view", "edit"],
    * });
    *
@@ -226,14 +234,26 @@ export abstract class Client {
    * @example
    * ```typescript
    * const decision = await cerbos.checkResources({
-   *   principal: { id: "user@example.com", roles: ["USER"] },
+   *   principal: {
+   *     id: "user@example.com",
+   *     roles: ["USER"],
+   *     attributes: { tier: "PREMIUM" },
+   *   },
    *   resources: [
    *     {
-   *       resource: { kind: "document", id: "1" },
+   *       resource: {
+   *         kind: "document",
+   *         id: "1",
+   *         attributes: { owner: "user@example.com" },
+   *       },
    *       actions: ["view", "edit"],
    *     },
    *     {
-   *       resource: { kind: "image", id: "1" },
+   *       resource: {
+   *         kind: "image",
+   *         id: "1",
+   *         attributes: { owner: "user@example.com" },
+   *       },
    *       actions: ["delete"],
    *     },
    *   ],
@@ -406,8 +426,16 @@ export abstract class Client {
    * @example
    * ```typescript
    * await cerbos.isAllowed({
-   *   principal: { id: "user@example.com", roles: ["USER"] },
-   *   resource: { kind: "document", id: "1" },
+   *   principal: {
+   *     id: "user@example.com",
+   *     roles: ["USER"],
+   *     attributes: { tier: "PREMIUM" },
+   *   },
+   *   resource: {
+   *     kind: "document",
+   *     id: "1",
+   *     attributes: { owner: "user@example.com" },
+   *   },
    *   action: "view",
    * }); // => true
    * ```
@@ -470,7 +498,11 @@ export abstract class Client {
    * @example
    * ```typescript
    * const plan = await cerbos.planResources({
-   *   principal: { id: "user@example.com", roles: ["USER"] },
+   *   principal: {
+   *     id: "user@example.com",
+   *     roles: ["USER"],
+   *     attributes: { tier: "PREMIUM" },
+   *   },
    *   resource: { kind: "document" },
    * });
    * ```

--- a/packages/grpc/CHANGELOG.md
+++ b/packages/grpc/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - Bump dependency on [@grpc/grpc-js](https://github.com/grpc/grpc-node) to 1.7.3 ([#254](https://github.com/cerbos/cerbos-sdk-javascript/pull/254), [#273](https://github.com/cerbos/cerbos-sdk-javascript/pull/273), [#298](https://github.com/cerbos/cerbos-sdk-javascript/pull/298), [#323](https://github.com/cerbos/cerbos-sdk-javascript/pull/323))
+- Document principal and resource `attributes` fields in examples ([#358](https://github.com/cerbos/cerbos-sdk-javascript/pull/358))
 
 ## [0.8.0] - 2022-09-08
 

--- a/packages/grpc/README.md
+++ b/packages/grpc/README.md
@@ -29,8 +29,16 @@ import { GRPC } from "@cerbos/grpc";
 const cerbos = new GRPC("localhost:3593", { tls: false });
 
 await cerbos.isAllowed({
-  principal: { id: "user@example.com", roles: ["USER"] },
-  resource: { kind: "document", id: "1" },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
+  resource: {
+    kind: "document",
+    id: "1",
+    attributes: { owner: "user@example.com" },
+  },
   action: "view",
 }); // => true
 ```

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Document principal and resource `attributes` fields in examples ([#358](https://github.com/cerbos/cerbos-sdk-javascript/pull/358))
 
 ## [0.8.0] - 2022-09-08
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -39,8 +39,16 @@ import { HTTP } from "@cerbos/http";
 const cerbos = new HTTP("http://localhost:3592");
 
 await cerbos.isAllowed({
-  principal: { id: "user@example.com", roles: ["USER"] },
-  resource: { kind: "document", id: "1" },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
+  resource: {
+    kind: "document",
+    id: "1",
+    attributes: { owner: "user@example.com" },
+  },
   action: "view",
 }); // => true
 ```

--- a/packages/lite/CHANGELOG.md
+++ b/packages/lite/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Document principal and resource `attributes` fields in examples ([#358](https://github.com/cerbos/cerbos-sdk-javascript/pull/358))
 
 ## [0.1.0-alpha] - 2022-09-08
 

--- a/packages/lite/README.md
+++ b/packages/lite/README.md
@@ -30,8 +30,16 @@ import { Lite } from "@cerbos/lite";
 const cerbos = new Lite(fetch("/policies.wasm"));
 
 await cerbos.isAllowed({
-  principal: { id: "user@example.com", roles: ["USER"] },
-  resource: { kind: "document", id: "1" },
+  principal: {
+    id: "user@example.com",
+    roles: ["USER"],
+    attributes: { tier: "PREMIUM" },
+  },
+  resource: {
+    kind: "document",
+    id: "1",
+    attributes: { owner: "user@example.com" },
+  },
   action: "view",
 }); // => true
 ```


### PR DESCRIPTION
As pointed out on the [community Slack](https://cerboscommunity.slack.com/archives/C02A364JYMQ/p1669213004315769), the examples don't include the principal or resource `attributes` field, which is a bit unhelpful especially given the SDK differs from the underlying API (where it's `attr`).