### PR TITLE
chore: Use function declarations to get proper documentation

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -28,6 +28,9 @@ rules:
     - error
     - always
   curly: error
+  func-style:
+    - error
+    - declaration
   import/no-duplicates: error
   import/no-extraneous-dependencies:
     - error

--- a/docs/core.matchismatchall.md
+++ b/docs/core.matchismatchall.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [matchIsMatchAll](./core.matchismatchall.md)
 
-## matchIsMatchAll variable
+## matchIsMatchAll() function
 
 Type guard to check if a [Match](./core.match.md) is a [MatchAll](./core.matchall.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-matchIsMatchAll: (match: Match) => match is MatchAll
+export declare function matchIsMatchAll(match: Match): match is MatchAll;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  match | [Match](./core.match.md) |  |
+
+**Returns:**
+
+match is [MatchAll](./core.matchall.md)
+

--- a/docs/core.matchismatchany.md
+++ b/docs/core.matchismatchany.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [matchIsMatchAny](./core.matchismatchany.md)
 
-## matchIsMatchAny variable
+## matchIsMatchAny() function
 
 Type guard to check if a [Match](./core.match.md) is a [MatchAny](./core.matchany.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-matchIsMatchAny: (match: Match) => match is MatchAny
+export declare function matchIsMatchAny(match: Match): match is MatchAny;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  match | [Match](./core.match.md) |  |
+
+**Returns:**
+
+match is [MatchAny](./core.matchany.md)
+

--- a/docs/core.matchismatchexpr.md
+++ b/docs/core.matchismatchexpr.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [matchIsMatchExpr](./core.matchismatchexpr.md)
 
-## matchIsMatchExpr variable
+## matchIsMatchExpr() function
 
 Type guard to check if a [Match](./core.match.md) is a [MatchExpr](./core.matchexpr.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-matchIsMatchExpr: (match: Match) => match is MatchExpr
+export declare function matchIsMatchExpr(match: Match): match is MatchExpr;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  match | [Match](./core.match.md) |  |
+
+**Returns:**
+
+match is [MatchExpr](./core.matchexpr.md)
+

--- a/docs/core.matchismatchnone.md
+++ b/docs/core.matchismatchnone.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [matchIsMatchNone](./core.matchismatchnone.md)
 
-## matchIsMatchNone variable
+## matchIsMatchNone() function
 
 Type guard to check if a [Match](./core.match.md) is a [MatchNone](./core.matchnone.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-matchIsMatchNone: (match: Match) => match is MatchNone
+export declare function matchIsMatchNone(match: Match): match is MatchNone;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  match | [Match](./core.match.md) |  |
+
+**Returns:**
+
+match is [MatchNone](./core.matchnone.md)
+

--- a/docs/core.md
+++ b/docs/core.md
@@ -34,6 +34,19 @@ Common types used by the [gRPC](./grpc.md) and [HTTP](./http.md) client librarie
 |  [Status](./core.status.md) | Status codes returned by the Cerbos policy decision point server. |
 |  [ValidationErrorSource](./core.validationerrorsource.md) | Sources of invalid attributes. |
 
+## Functions
+
+|  Function | Description |
+|  --- | --- |
+|  [matchIsMatchAll(match)](./core.matchismatchall.md) | Type guard to check if a [Match](./core.match.md) is a [MatchAll](./core.matchall.md)<!-- -->. |
+|  [matchIsMatchAny(match)](./core.matchismatchany.md) | Type guard to check if a [Match](./core.match.md) is a [MatchAny](./core.matchany.md)<!-- -->. |
+|  [matchIsMatchExpr(match)](./core.matchismatchexpr.md) | Type guard to check if a [Match](./core.match.md) is a [MatchExpr](./core.matchexpr.md)<!-- -->. |
+|  [matchIsMatchNone(match)](./core.matchismatchnone.md) | Type guard to check if a [Match](./core.match.md) is a [MatchNone](./core.matchnone.md)<!-- -->. |
+|  [policyIsDerivedRoles(policy)](./core.policyisderivedroles.md) | Type guard to check if a [Policy](./core.policy.md) is a set of [DerivedRoles](./core.derivedroles.md)<!-- -->. |
+|  [policyIsExportVariables(policy)](./core.policyisexportvariables.md) | Type guard to check if a [Policy](./core.policy.md) is a set of [ExportVariables](./core.exportvariables.md)<!-- -->. |
+|  [policyIsPrincipalPolicy(policy)](./core.policyisprincipalpolicy.md) | Type guard to check if a [Policy](./core.policy.md) is a [PrincipalPolicy](./core.principalpolicy.md)<!-- -->. |
+|  [policyIsResourcePolicy(policy)](./core.policyisresourcepolicy.md) | Type guard to check if a [Policy](./core.policy.md) is a [ResourcePolicy](./core.resourcepolicy.md)<!-- -->. |
+
 ## Interfaces
 
 |  Interface | Description |
@@ -99,19 +112,6 @@ Common types used by the [gRPC](./grpc.md) and [HTTP](./http.md) client librarie
 |  [ServerInfo](./core.serverinfo.md) | Information about the Cerbos policy decision point (PDP) server. |
 |  [ValidationError](./core.validationerror.md) | An error that occurred while validating the principal or resource attributes against a schema. |
 |  [Variables](./core.variables.md) | [Variables](https://docs.cerbos.dev/cerbos/latest/policies/variables.html) defined for use in policy conditions. |
-
-## Variables
-
-|  Variable | Description |
-|  --- | --- |
-|  [matchIsMatchAll](./core.matchismatchall.md) | Type guard to check if a [Match](./core.match.md) is a [MatchAll](./core.matchall.md)<!-- -->. |
-|  [matchIsMatchAny](./core.matchismatchany.md) | Type guard to check if a [Match](./core.match.md) is a [MatchAny](./core.matchany.md)<!-- -->. |
-|  [matchIsMatchExpr](./core.matchismatchexpr.md) | Type guard to check if a [Match](./core.match.md) is a [MatchExpr](./core.matchexpr.md)<!-- -->. |
-|  [matchIsMatchNone](./core.matchismatchnone.md) | Type guard to check if a [Match](./core.match.md) is a [MatchNone](./core.matchnone.md)<!-- -->. |
-|  [policyIsDerivedRoles](./core.policyisderivedroles.md) | Type guard to check if a [Policy](./core.policy.md) is a set of [DerivedRoles](./core.derivedroles.md)<!-- -->. |
-|  [policyIsExportVariables](./core.policyisexportvariables.md) | Type guard to check if a [Policy](./core.policy.md) is a set of [ExportVariables](./core.exportvariables.md)<!-- -->. |
-|  [policyIsPrincipalPolicy](./core.policyisprincipalpolicy.md) | Type guard to check if a [Policy](./core.policy.md) is a [PrincipalPolicy](./core.principalpolicy.md)<!-- -->. |
-|  [policyIsResourcePolicy](./core.policyisresourcepolicy.md) | Type guard to check if a [Policy](./core.policy.md) is a [ResourcePolicy](./core.resourcepolicy.md)<!-- -->. |
 
 ## Type Aliases
 

--- a/docs/core.policyisderivedroles.md
+++ b/docs/core.policyisderivedroles.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [policyIsDerivedRoles](./core.policyisderivedroles.md)
 
-## policyIsDerivedRoles variable
+## policyIsDerivedRoles() function
 
 Type guard to check if a [Policy](./core.policy.md) is a set of [DerivedRoles](./core.derivedroles.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-policyIsDerivedRoles: (policy: Policy) => policy is DerivedRoles
+export declare function policyIsDerivedRoles(policy: Policy): policy is DerivedRoles;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  policy | [Policy](./core.policy.md) |  |
+
+**Returns:**
+
+policy is [DerivedRoles](./core.derivedroles.md)
+

--- a/docs/core.policyisexportvariables.md
+++ b/docs/core.policyisexportvariables.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [policyIsExportVariables](./core.policyisexportvariables.md)
 
-## policyIsExportVariables variable
+## policyIsExportVariables() function
 
 Type guard to check if a [Policy](./core.policy.md) is a set of [ExportVariables](./core.exportvariables.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-policyIsExportVariables: (policy: Policy) => policy is ExportVariables
+export declare function policyIsExportVariables(policy: Policy): policy is ExportVariables;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  policy | [Policy](./core.policy.md) |  |
+
+**Returns:**
+
+policy is [ExportVariables](./core.exportvariables.md)
+

--- a/docs/core.policyisprincipalpolicy.md
+++ b/docs/core.policyisprincipalpolicy.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [policyIsPrincipalPolicy](./core.policyisprincipalpolicy.md)
 
-## policyIsPrincipalPolicy variable
+## policyIsPrincipalPolicy() function
 
 Type guard to check if a [Policy](./core.policy.md) is a [PrincipalPolicy](./core.principalpolicy.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-policyIsPrincipalPolicy: (policy: Policy) => policy is PrincipalPolicy
+export declare function policyIsPrincipalPolicy(policy: Policy): policy is PrincipalPolicy;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  policy | [Policy](./core.policy.md) |  |
+
+**Returns:**
+
+policy is [PrincipalPolicy](./core.principalpolicy.md)
+

--- a/docs/core.policyisresourcepolicy.md
+++ b/docs/core.policyisresourcepolicy.md
@@ -2,12 +2,23 @@
 
 [Home](./index.md) &gt; [@cerbos/core](./core.md) &gt; [policyIsResourcePolicy](./core.policyisresourcepolicy.md)
 
-## policyIsResourcePolicy variable
+## policyIsResourcePolicy() function
 
 Type guard to check if a [Policy](./core.policy.md) is a [ResourcePolicy](./core.resourcepolicy.md)<!-- -->.
 
 **Signature:**
 
 ```typescript
-policyIsResourcePolicy: (policy: Policy) => policy is ResourcePolicy
+export declare function policyIsResourcePolicy(policy: Policy): policy is ResourcePolicy;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  policy | [Policy](./core.policy.md) |  |
+
+**Returns:**
+
+policy is [ResourcePolicy](./core.resourcepolicy.md)
+

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -68,14 +68,14 @@ export type _Instrumenter = (transport: _Transport) => _Transport;
 const instrumenters = new Set<_Instrumenter>();
 
 /** @internal */
-export const _addInstrumenter = (instrumenter: _Instrumenter): void => {
+export function _addInstrumenter(instrumenter: _Instrumenter): void {
   instrumenters.add(instrumenter);
-};
+}
 
 /** @internal */
-export const _removeInstrumenter = (instrumenter: _Instrumenter): void => {
+export function _removeInstrumenter(instrumenter: _Instrumenter): void {
   instrumenters.delete(instrumenter);
-};
+}
 
 /**
  * Options for creating a new {@link Client}.

--- a/packages/core/src/convert/fromProtobuf.ts
+++ b/packages/core/src/convert/fromProtobuf.ts
@@ -88,22 +88,23 @@ import type { DeleteSchemasResponse } from "../types/external/DeleteSchemasRespo
 import type { GetSchemasResponse } from "../types/external/GetSchemasResponse";
 import type { OmitFromEach } from "../types/internal";
 
-export const checkResourcesResponseFromProtobuf = ({
+export function checkResourcesResponseFromProtobuf({
   requestId,
   results,
-}: CheckResourcesResponseProtobuf): CheckResourcesResponse =>
-  new CheckResourcesResponse({
+}: CheckResourcesResponseProtobuf): CheckResourcesResponse {
+  return new CheckResourcesResponse({
     requestId,
     results: results.map(checkResourcesResultFromProtobuf),
   });
+}
 
-const checkResourcesResultFromProtobuf = ({
+function checkResourcesResultFromProtobuf({
   resource,
   actions,
   validationErrors,
   meta,
   outputs,
-}: CheckResourcesResponse_ResultEntry): CheckResourcesResult => {
+}: CheckResourcesResponse_ResultEntry): CheckResourcesResult {
   if (!resource) {
     throw new Error("Missing resource on CheckResources result");
   }
@@ -115,34 +116,38 @@ const checkResourcesResultFromProtobuf = ({
     metadata: meta,
     outputs: outputs.map(outputResultFromProtobuf),
   });
-};
+}
 
-const actionsFromProtobuf = (
+function actionsFromProtobuf(
   actions: Record<string, EffectProtobuf>,
-): Record<string, Effect | undefined> =>
-  Object.fromEntries(
+): Record<string, Effect | undefined> {
+  return Object.fromEntries(
     Object.entries(actions).map(([action, effect]) => [
       action,
       effectFromProtobuf(effect),
     ]),
   );
+}
 
-const effectFromProtobuf = (effect: EffectProtobuf): Effect =>
-  effect === EffectProtobuf.EFFECT_ALLOW ? Effect.ALLOW : Effect.DENY;
+function effectFromProtobuf(effect: EffectProtobuf): Effect {
+  return effect === EffectProtobuf.EFFECT_ALLOW ? Effect.ALLOW : Effect.DENY;
+}
 
-const validationErrorFromProtobuf = ({
+function validationErrorFromProtobuf({
   path,
   message,
   source,
-}: ValidationErrorProtobuf): ValidationError => ({
-  path,
-  message,
-  source: validationErrorSourceFromProtobuf(source),
-});
+}: ValidationErrorProtobuf): ValidationError {
+  return {
+    path,
+    message,
+    source: validationErrorSourceFromProtobuf(source),
+  };
+}
 
-const validationErrorSourceFromProtobuf = (
+function validationErrorSourceFromProtobuf(
   source: ValidationError_Source,
-): ValidationErrorSource => {
+): ValidationErrorSource {
   switch (source) {
     case ValidationError_Source.SOURCE_PRINCIPAL:
       return ValidationErrorSource.PRINCIPAL;
@@ -157,73 +162,87 @@ const validationErrorSourceFromProtobuf = (
         })`,
       );
   }
-};
+}
 
-const outputResultFromProtobuf = ({ src, val }: OutputEntry): OutputResult => ({
-  source: src,
-  value: val as Value | undefined,
-});
+function outputResultFromProtobuf({ src, val }: OutputEntry): OutputResult {
+  return {
+    source: src,
+    value: val as Value | undefined,
+  };
+}
 
-export const deleteSchemasResponseFromProtobuf = ({
+export function deleteSchemasResponseFromProtobuf({
   deletedSchemas,
-}: DeleteSchemaResponse): DeleteSchemasResponse => ({
-  deletedSchemas,
-});
+}: DeleteSchemaResponse): DeleteSchemasResponse {
+  return {
+    deletedSchemas,
+  };
+}
 
-export const disablePoliciesResponseFromProtobuf = ({
+export function disablePoliciesResponseFromProtobuf({
   disabledPolicies,
-}: DisablePolicyResponse): DisablePoliciesResponse => ({
-  disabledPolicies,
-});
+}: DisablePolicyResponse): DisablePoliciesResponse {
+  return {
+    disabledPolicies,
+  };
+}
 
-export const enablePoliciesResponseFromProtobuf = ({
+export function enablePoliciesResponseFromProtobuf({
   enabledPolicies,
-}: EnablePolicyResponse): EnablePoliciesResponse => ({
-  enabledPolicies,
-});
+}: EnablePolicyResponse): EnablePoliciesResponse {
+  return {
+    enabledPolicies,
+  };
+}
 
-export const getPoliciesResponseFromProtobuf = ({
+export function getPoliciesResponseFromProtobuf({
   policies,
-}: GetPolicyResponse): GetPoliciesResponse => ({
-  policies: policies.map(_policyFromProtobuf),
-});
+}: GetPolicyResponse): GetPoliciesResponse {
+  return {
+    policies: policies.map(_policyFromProtobuf),
+  };
+}
 
 /** @internal */
-export const _policyFromProtobuf = ({
+export function _policyFromProtobuf({
   apiVersion,
   description,
   disabled,
   metadata,
   variables,
   policyType,
-}: PolicyProtobuf): Policy => ({
-  apiVersion,
-  description,
-  disabled,
-  metadata: metadata && policyMetadataFromProtobuf(metadata),
-  variables,
-  ...policyTypeFromProtobuf(policyType),
-});
+}: PolicyProtobuf): Policy {
+  return {
+    apiVersion,
+    description,
+    disabled,
+    metadata: metadata && policyMetadataFromProtobuf(metadata),
+    variables,
+    ...policyTypeFromProtobuf(policyType),
+  };
+}
 
-const policyMetadataFromProtobuf = ({
+function policyMetadataFromProtobuf({
   annotations,
   hash,
   sourceFile,
   storeIdentifer,
   storeIdentifier,
-}: Metadata): PolicyMetadata => ({
-  annotations,
-  hash,
-  sourceFile,
-  storeIdentifer: storeIdentifier || storeIdentifer,
-  storeIdentifier: storeIdentifier || storeIdentifer,
-});
+}: Metadata): PolicyMetadata {
+  return {
+    annotations,
+    hash,
+    sourceFile,
+    storeIdentifer: storeIdentifier || storeIdentifer,
+    storeIdentifier: storeIdentifier || storeIdentifer,
+  };
+}
 
 type OmitPolicyBase<T extends Policy> = OmitFromEach<T, keyof PolicyBase>;
 
-const policyTypeFromProtobuf = (
+function policyTypeFromProtobuf(
   policyType: PolicyProtobuf["policyType"],
-): OmitPolicyBase<Policy> => {
+): OmitPolicyBase<Policy> {
   if (!policyType) {
     throw new Error("Unknown policy type: undefined");
   }
@@ -246,31 +265,35 @@ const policyTypeFromProtobuf = (
         `Unknown policy type: ${JSON.stringify(policyType, null, 2)}`,
       );
   }
-};
+}
 
-const derivedRolesFromProtobuf = ({
+function derivedRolesFromProtobuf({
   name,
   definitions,
   variables,
-}: DerivedRolesProtobuf): OmitPolicyBase<DerivedRoles> => ({
-  derivedRoles: {
-    name,
-    definitions: definitions.map(derivedRoleDefinitionFromProtobuf),
-    variables: variables && variablesFromProtobuf(variables),
-  },
-});
+}: DerivedRolesProtobuf): OmitPolicyBase<DerivedRoles> {
+  return {
+    derivedRoles: {
+      name,
+      definitions: definitions.map(derivedRoleDefinitionFromProtobuf),
+      variables: variables && variablesFromProtobuf(variables),
+    },
+  };
+}
 
-const derivedRoleDefinitionFromProtobuf = ({
+function derivedRoleDefinitionFromProtobuf({
   name,
   parentRoles,
   condition,
-}: RoleDef): DerivedRoleDefinition => ({
-  name,
-  parentRoles,
-  condition: condition && conditionFromProtobuf(condition),
-});
+}: RoleDef): DerivedRoleDefinition {
+  return {
+    name,
+    parentRoles,
+    condition: condition && conditionFromProtobuf(condition),
+  };
+}
 
-const conditionFromProtobuf = ({ condition }: ConditionProtobuf): Condition => {
+function conditionFromProtobuf({ condition }: ConditionProtobuf): Condition {
   switch (condition?.$case) {
     case "match":
       return {
@@ -282,9 +305,9 @@ const conditionFromProtobuf = ({ condition }: ConditionProtobuf): Condition => {
         `Unknown condition type: ${JSON.stringify(condition, null, 2)}`,
       );
   }
-};
+}
 
-const matchFromProtobuf = ({ op }: MatchProtobuf): Match => {
+function matchFromProtobuf({ op }: MatchProtobuf): Match {
   switch (op?.$case) {
     case "all":
       return {
@@ -309,71 +332,85 @@ const matchFromProtobuf = ({ op }: MatchProtobuf): Match => {
     default:
       throw new Error(`Unknown match type: ${JSON.stringify(op, null, 2)}`);
   }
-};
+}
 
-const matchesFromProtobuf = ({ of }: Match_ExprList): Matches => ({
-  of: of.map(matchFromProtobuf),
-});
+function matchesFromProtobuf({ of }: Match_ExprList): Matches {
+  return {
+    of: of.map(matchFromProtobuf),
+  };
+}
 
-const variablesFromProtobuf = ({
+function variablesFromProtobuf({
   import: imports,
   local,
-}: VariablesProtobuf): Variables => ({
-  import: imports,
-  local,
-});
+}: VariablesProtobuf): Variables {
+  return {
+    import: imports,
+    local,
+  };
+}
 
-const exportVariablesFromProtobuf = ({
+function exportVariablesFromProtobuf({
   name,
   definitions,
-}: ExportVariablesProtobuf): OmitPolicyBase<ExportVariables> => ({
-  exportVariables: {
-    name,
-    definitions,
-  },
-});
+}: ExportVariablesProtobuf): OmitPolicyBase<ExportVariables> {
+  return {
+    exportVariables: {
+      name,
+      definitions,
+    },
+  };
+}
 
-const principalPolicyFromProtobuf = ({
+function principalPolicyFromProtobuf({
   principal,
   version,
   rules,
   scope,
   variables,
-}: PrincipalPolicyProtobuf): OmitPolicyBase<PrincipalPolicy> => ({
-  principalPolicy: {
-    principal,
-    version,
-    rules: rules.map(principalRuleFromProtobuf),
-    scope,
-    variables: variables && variablesFromProtobuf(variables),
-  },
-});
+}: PrincipalPolicyProtobuf): OmitPolicyBase<PrincipalPolicy> {
+  return {
+    principalPolicy: {
+      principal,
+      version,
+      rules: rules.map(principalRuleFromProtobuf),
+      scope,
+      variables: variables && variablesFromProtobuf(variables),
+    },
+  };
+}
 
-const principalRuleFromProtobuf = ({
+function principalRuleFromProtobuf({
   resource,
   actions,
-}: PrincipalRuleProtobuf): PrincipalRule => ({
-  resource,
-  actions: actions.map(principalRuleActionFromProtobuf),
-});
+}: PrincipalRuleProtobuf): PrincipalRule {
+  return {
+    resource,
+    actions: actions.map(principalRuleActionFromProtobuf),
+  };
+}
 
-const principalRuleActionFromProtobuf = ({
+function principalRuleActionFromProtobuf({
   action,
   effect,
   condition,
   name,
   output,
-}: PrincipalRule_Action): PrincipalRuleAction => ({
-  action,
-  effect: effectFromProtobuf(effect),
-  condition: condition && conditionFromProtobuf(condition),
-  name,
-  output: output && outputFromProtobuf(output),
-});
+}: PrincipalRule_Action): PrincipalRuleAction {
+  return {
+    action,
+    effect: effectFromProtobuf(effect),
+    condition: condition && conditionFromProtobuf(condition),
+    name,
+    output: output && outputFromProtobuf(output),
+  };
+}
 
-const outputFromProtobuf = ({ expr }: OutputProtobuf): Output => ({ expr });
+function outputFromProtobuf({ expr }: OutputProtobuf): Output {
+  return { expr };
+}
 
-const resourcePolicyFromProtobuf = ({
+function resourcePolicyFromProtobuf({
   resource,
   version,
   importDerivedRoles,
@@ -381,19 +418,21 @@ const resourcePolicyFromProtobuf = ({
   schemas,
   scope,
   variables,
-}: ResourcePolicyProtobuf): OmitPolicyBase<ResourcePolicy> => ({
-  resourcePolicy: {
-    resource,
-    version,
-    importDerivedRoles,
-    rules: rules.map(resourceRuleFromProtobuf),
-    schemas: schemas && schemaRefsFromProtobuf(schemas),
-    scope,
-    variables: variables && variablesFromProtobuf(variables),
-  },
-});
+}: ResourcePolicyProtobuf): OmitPolicyBase<ResourcePolicy> {
+  return {
+    resourcePolicy: {
+      resource,
+      version,
+      importDerivedRoles,
+      rules: rules.map(resourceRuleFromProtobuf),
+      schemas: schemas && schemaRefsFromProtobuf(schemas),
+      scope,
+      variables: variables && variablesFromProtobuf(variables),
+    },
+  };
+}
 
-const resourceRuleFromProtobuf = ({
+function resourceRuleFromProtobuf({
   actions,
   effect,
   derivedRoles,
@@ -401,63 +440,74 @@ const resourceRuleFromProtobuf = ({
   condition,
   name,
   output,
-}: ResourceRuleProtobuf): ResourceRule => ({
-  actions,
-  effect: effectFromProtobuf(effect),
-  derivedRoles,
-  roles,
-  condition: condition && conditionFromProtobuf(condition),
-  name,
-  output: output && outputFromProtobuf(output),
-});
+}: ResourceRuleProtobuf): ResourceRule {
+  return {
+    actions,
+    effect: effectFromProtobuf(effect),
+    derivedRoles,
+    roles,
+    condition: condition && conditionFromProtobuf(condition),
+    name,
+    output: output && outputFromProtobuf(output),
+  };
+}
 
-const schemaRefsFromProtobuf = ({
+function schemaRefsFromProtobuf({
   principalSchema,
   resourceSchema,
-}: Schemas): SchemaRefs => ({
-  principalSchema: principalSchema && schemaRefFromProtobuf(principalSchema),
-  resourceSchema: resourceSchema && schemaRefFromProtobuf(resourceSchema),
-});
+}: Schemas): SchemaRefs {
+  return {
+    principalSchema: principalSchema && schemaRefFromProtobuf(principalSchema),
+    resourceSchema: resourceSchema && schemaRefFromProtobuf(resourceSchema),
+  };
+}
 
-const schemaRefFromProtobuf = ({
-  ref,
-  ignoreWhen,
-}: Schemas_Schema): SchemaRef => ({
-  ref,
-  ignoreWhen: ignoreWhen && {
-    actions: ignoreWhen.actions,
-  },
-});
+function schemaRefFromProtobuf({ ref, ignoreWhen }: Schemas_Schema): SchemaRef {
+  return {
+    ref,
+    ignoreWhen: ignoreWhen && {
+      actions: ignoreWhen.actions,
+    },
+  };
+}
 
-export const getSchemasResponseFromProtobuf = ({
+export function getSchemasResponseFromProtobuf({
   schemas,
-}: GetSchemaResponse): GetSchemasResponse => ({
-  schemas: schemas.map(schemaFromProtobuf),
-});
+}: GetSchemaResponse): GetSchemasResponse {
+  return {
+    schemas: schemas.map(schemaFromProtobuf),
+  };
+}
 
-const schemaFromProtobuf = ({ id, definition }: SchemaProtobuf): Schema => ({
-  id,
-  definition: new SchemaDefinition(definition),
-});
+function schemaFromProtobuf({ id, definition }: SchemaProtobuf): Schema {
+  return {
+    id,
+    definition: new SchemaDefinition(definition),
+  };
+}
 
-export const listPoliciesResponseFromProtobuf = ({
+export function listPoliciesResponseFromProtobuf({
   policyIds,
-}: ListPoliciesResponseProtobuf): ListPoliciesResponse => ({
-  ids: policyIds,
-});
+}: ListPoliciesResponseProtobuf): ListPoliciesResponse {
+  return {
+    ids: policyIds,
+  };
+}
 
-export const listSchemasResponseFromProtobuf = ({
+export function listSchemasResponseFromProtobuf({
   schemaIds,
-}: ListSchemasResponseProtobuf): ListSchemasResponse => ({
-  ids: schemaIds,
-});
+}: ListSchemasResponseProtobuf): ListSchemasResponse {
+  return {
+    ids: schemaIds,
+  };
+}
 
-export const planResourcesResponseFromProtobuf = ({
+export function planResourcesResponseFromProtobuf({
   requestId,
   filter,
   validationErrors,
   meta,
-}: PlanResourcesResponseProtobuf): PlanResourcesResponse => {
+}: PlanResourcesResponseProtobuf): PlanResourcesResponse {
   if (!filter) {
     throw new Error("Missing filter on PlanResources response");
   }
@@ -485,9 +535,9 @@ export const planResourcesResponseFromProtobuf = ({
     validationErrors: validationErrors.map(validationErrorFromProtobuf),
     metadata,
   };
-};
+}
 
-const planKindFromProtobuf = (kind: PlanResourcesFilter_Kind): PlanKind => {
+function planKindFromProtobuf(kind: PlanResourcesFilter_Kind): PlanKind {
   switch (kind) {
     case PlanResourcesFilter_Kind.KIND_ALWAYS_ALLOWED:
       return PlanKind.ALWAYS_ALLOWED;
@@ -505,11 +555,11 @@ const planKindFromProtobuf = (kind: PlanResourcesFilter_Kind): PlanKind => {
         })`,
       );
   }
-};
+}
 
-const planOperandFromProtobuf = ({
+function planOperandFromProtobuf({
   node,
-}: PlanResourcesFilter_Expression_Operand): PlanExpressionOperand => {
+}: PlanResourcesFilter_Expression_Operand): PlanExpressionOperand {
   if (!node) {
     throw new Error("Missing node on PlanResources expression operand");
   }
@@ -527,12 +577,14 @@ const planOperandFromProtobuf = ({
     case "variable":
       return new PlanExpressionVariable(node.variable);
   }
-};
+}
 
-const planResourcesMetadataFromProtobuf = ({
+function planResourcesMetadataFromProtobuf({
   filterDebug,
   matchedScope,
-}: PlanResourcesResponse_Meta): PlanResourcesMetadata => ({
-  conditionString: filterDebug,
-  matchedScope,
-});
+}: PlanResourcesResponse_Meta): PlanResourcesMetadata {
+  return {
+    conditionString: filterDebug,
+    matchedScope,
+  };
+}

--- a/packages/core/src/convert/toProtobuf.ts
+++ b/packages/core/src/convert/toProtobuf.ts
@@ -91,13 +91,15 @@ import type { GetSchemasRequest } from "../types/external/GetSchemasRequest";
 
 const encoder = new TextEncoder();
 
-export const addOrUpdatePoliciesRequestToProtobuf = ({
+export function addOrUpdatePoliciesRequestToProtobuf({
   policies,
-}: AddOrUpdatePoliciesRequest): AddOrUpdatePolicyRequest => ({
-  policies: policies.map(policyToProtobuf),
-});
+}: AddOrUpdatePoliciesRequest): AddOrUpdatePolicyRequest {
+  return {
+    policies: policies.map(policyToProtobuf),
+  };
+}
 
-const policyToProtobuf = (policy: Policy): PolicyProtobuf => {
+function policyToProtobuf(policy: Policy): PolicyProtobuf {
   const {
     apiVersion = "api.cerbos.dev/v1",
     description = "",
@@ -114,11 +116,11 @@ const policyToProtobuf = (policy: Policy): PolicyProtobuf => {
     policyType: policyTypeToProtobuf(policy),
     variables,
   };
-};
+}
 
-const policyTypeToProtobuf = (
+function policyTypeToProtobuf(
   policy: Policy,
-): Exclude<PolicyProtobuf["policyType"], undefined> => {
+): Exclude<PolicyProtobuf["policyType"], undefined> {
   if (policyIsDerivedRoles(policy)) {
     return {
       $case: "derivedRoles",
@@ -148,34 +150,40 @@ const policyTypeToProtobuf = (
   }
 
   throw new Error(`Unknown policy type: ${JSON.stringify(policy, null, 2)}`);
-};
+}
 
-const derivedRolesToProtobuf = ({
+function derivedRolesToProtobuf({
   derivedRoles: { name, definitions, variables },
-}: DerivedRoles): DerivedRolesProtobuf => ({
-  name,
-  definitions: definitions.map(derivedRoleDefinitionToProtobuf),
-  variables: variables && variablesToProtobuf(variables),
-});
+}: DerivedRoles): DerivedRolesProtobuf {
+  return {
+    name,
+    definitions: definitions.map(derivedRoleDefinitionToProtobuf),
+    variables: variables && variablesToProtobuf(variables),
+  };
+}
 
-const derivedRoleDefinitionToProtobuf = ({
+function derivedRoleDefinitionToProtobuf({
   name,
   parentRoles,
   condition,
-}: DerivedRoleDefinition): RoleDef => ({
-  name,
-  parentRoles,
-  condition: condition && conditionToProtobuf(condition),
-});
+}: DerivedRoleDefinition): RoleDef {
+  return {
+    name,
+    parentRoles,
+    condition: condition && conditionToProtobuf(condition),
+  };
+}
 
-const conditionToProtobuf = ({ match }: Condition): ConditionProtobuf => ({
-  condition: {
-    $case: "match",
-    match: matchToProtobuf(match),
-  },
-});
+function conditionToProtobuf({ match }: Condition): ConditionProtobuf {
+  return {
+    condition: {
+      $case: "match",
+      match: matchToProtobuf(match),
+    },
+  };
+}
 
-const matchToProtobuf = (match: Match): MatchProtobuf => {
+function matchToProtobuf(match: Match): MatchProtobuf {
   if (matchIsMatchAll(match)) {
     return {
       op: {
@@ -213,67 +221,82 @@ const matchToProtobuf = (match: Match): MatchProtobuf => {
   }
 
   throw new Error(`Unknown match type: ${JSON.stringify(match, null, 2)}`);
-};
+}
 
-const matchesToProtobuf = ({ of }: Matches): Match_ExprList => ({
-  of: of.map(matchToProtobuf),
-});
+function matchesToProtobuf({ of }: Matches): Match_ExprList {
+  return {
+    of: of.map(matchToProtobuf),
+  };
+}
 
-const variablesToProtobuf = ({
+function variablesToProtobuf({
   import: imports = [],
   local = {},
-}: Variables): VariablesProtobuf => ({
-  import: imports,
-  local,
-});
+}: Variables): VariablesProtobuf {
+  return {
+    import: imports,
+    local,
+  };
+}
 
-const exportVariablesToProtobuf = ({
+function exportVariablesToProtobuf({
   exportVariables: { name, definitions },
-}: ExportVariables): ExportVariablesProtobuf => ({
-  name,
-  definitions,
-});
+}: ExportVariables): ExportVariablesProtobuf {
+  return {
+    name,
+    definitions,
+  };
+}
 
-const principalPolicyToProtobuf = ({
+function principalPolicyToProtobuf({
   principalPolicy: { principal, version, rules, scope = "", variables },
-}: PrincipalPolicy): PrincipalPolicyProtobuf => ({
-  principal,
-  version,
-  rules: rules.map(principalRuleToProtobuf),
-  scope,
-  variables: variables && variablesToProtobuf(variables),
-});
+}: PrincipalPolicy): PrincipalPolicyProtobuf {
+  return {
+    principal,
+    version,
+    rules: rules.map(principalRuleToProtobuf),
+    scope,
+    variables: variables && variablesToProtobuf(variables),
+  };
+}
 
-const principalRuleToProtobuf = ({
+function principalRuleToProtobuf({
   resource,
   actions,
-}: PrincipalRule): PrincipalRuleProtobuf => ({
-  resource,
-  actions: actions.map(principalRuleActionToProtobuf),
-});
+}: PrincipalRule): PrincipalRuleProtobuf {
+  return {
+    resource,
+    actions: actions.map(principalRuleActionToProtobuf),
+  };
+}
 
-const principalRuleActionToProtobuf = ({
+function principalRuleActionToProtobuf({
   action,
   effect,
   condition,
   name = "",
   output,
-}: PrincipalRuleAction): PrincipalRule_Action => ({
-  action,
-  effect: effectToProtobuf(effect),
-  condition: condition && conditionToProtobuf(condition),
-  name,
-  output: output && outputToProtobuf(output),
-});
+}: PrincipalRuleAction): PrincipalRule_Action {
+  return {
+    action,
+    effect: effectToProtobuf(effect),
+    condition: condition && conditionToProtobuf(condition),
+    name,
+    output: output && outputToProtobuf(output),
+  };
+}
 
-const effectToProtobuf = (effect: Effect): EffectProtobuf =>
-  effect === Effect.ALLOW
+function effectToProtobuf(effect: Effect): EffectProtobuf {
+  return effect === Effect.ALLOW
     ? EffectProtobuf.EFFECT_ALLOW
     : EffectProtobuf.EFFECT_DENY;
+}
 
-const outputToProtobuf = ({ expr }: Output): OutputProtobuf => ({ expr });
+function outputToProtobuf({ expr }: Output): OutputProtobuf {
+  return { expr };
+}
 
-const resourcePolicyToProtobuf = ({
+function resourcePolicyToProtobuf({
   resourcePolicy: {
     resource,
     version,
@@ -283,17 +306,19 @@ const resourcePolicyToProtobuf = ({
     schemas,
     variables,
   },
-}: ResourcePolicy): ResourcePolicyProtobuf => ({
-  resource,
-  version,
-  importDerivedRoles,
-  rules: rules.map(resourceRuleToProtobuf),
-  scope,
-  schemas: schemas && policySchemasToProtobuf(schemas),
-  variables: variables && variablesToProtobuf(variables),
-});
+}: ResourcePolicy): ResourcePolicyProtobuf {
+  return {
+    resource,
+    version,
+    importDerivedRoles,
+    rules: rules.map(resourceRuleToProtobuf),
+    scope,
+    schemas: schemas && policySchemasToProtobuf(schemas),
+    variables: variables && variablesToProtobuf(variables),
+  };
+}
 
-const resourceRuleToProtobuf = ({
+function resourceRuleToProtobuf({
   actions,
   effect,
   derivedRoles = [],
@@ -301,46 +326,56 @@ const resourceRuleToProtobuf = ({
   condition,
   name = "",
   output,
-}: ResourceRule): ResourceRuleProtobuf => ({
-  actions,
-  effect: effectToProtobuf(effect),
-  derivedRoles,
-  roles,
-  condition: condition && conditionToProtobuf(condition),
-  name,
-  output: output && outputToProtobuf(output),
-});
+}: ResourceRule): ResourceRuleProtobuf {
+  return {
+    actions,
+    effect: effectToProtobuf(effect),
+    derivedRoles,
+    roles,
+    condition: condition && conditionToProtobuf(condition),
+    name,
+    output: output && outputToProtobuf(output),
+  };
+}
 
-const policySchemasToProtobuf = ({
+function policySchemasToProtobuf({
   principalSchema,
   resourceSchema,
-}: SchemaRefs): Schemas => ({
-  principalSchema: principalSchema && policySchemaToProtobuf(principalSchema),
-  resourceSchema: resourceSchema && policySchemaToProtobuf(resourceSchema),
-});
+}: SchemaRefs): Schemas {
+  return {
+    principalSchema: principalSchema && policySchemaToProtobuf(principalSchema),
+    resourceSchema: resourceSchema && policySchemaToProtobuf(resourceSchema),
+  };
+}
 
-const policySchemaToProtobuf = ({
+function policySchemaToProtobuf({
   ref,
   ignoreWhen,
-}: SchemaRef): Schemas_Schema => ({
-  ref,
-  ignoreWhen,
-});
+}: SchemaRef): Schemas_Schema {
+  return {
+    ref,
+    ignoreWhen,
+  };
+}
 
-export const addOrUpdateSchemasRequestToProtobuf = ({
+export function addOrUpdateSchemasRequestToProtobuf({
   schemas,
-}: AddOrUpdateSchemasRequest): AddOrUpdateSchemaRequest => ({
-  schemas: schemas.map(schemaToProtobuf),
-});
+}: AddOrUpdateSchemasRequest): AddOrUpdateSchemaRequest {
+  return {
+    schemas: schemas.map(schemaToProtobuf),
+  };
+}
 
-const schemaToProtobuf = ({ id, definition }: SchemaInput): Schema => ({
-  id,
-  definition: schemaDefinitionToProtobuf(definition),
-});
+function schemaToProtobuf({ id, definition }: SchemaInput): Schema {
+  return {
+    id,
+    definition: schemaDefinitionToProtobuf(definition),
+  };
+}
 
-const schemaDefinitionToProtobuf = (
+function schemaDefinitionToProtobuf(
   definition: SchemaDefinitionInput,
-): Uint8Array => {
+): Uint8Array {
   if (definition instanceof Uint8Array) {
     return definition;
   }
@@ -354,133 +389,161 @@ const schemaDefinitionToProtobuf = (
   }
 
   return encoder.encode(JSON.stringify(definition));
-};
+}
 
-export const checkResourcesRequestToProtobuf = ({
+export function checkResourcesRequestToProtobuf({
   principal,
   resources,
   auxData,
   includeMetadata = false,
   requestId = uuidv4(),
-}: CheckResourcesRequest): CheckResourcesRequestProtobuf => ({
-  principal: principalToProtobuf(principal),
-  resources: resources.map(resourceCheckToProtobuf),
-  auxData: auxData && auxDataToProtobuf(auxData),
-  includeMeta: includeMetadata,
-  requestId,
-});
+}: CheckResourcesRequest): CheckResourcesRequestProtobuf {
+  return {
+    principal: principalToProtobuf(principal),
+    resources: resources.map(resourceCheckToProtobuf),
+    auxData: auxData && auxDataToProtobuf(auxData),
+    includeMeta: includeMetadata,
+    requestId,
+  };
+}
 
-const principalToProtobuf = ({
+function principalToProtobuf({
   id,
   roles,
   attributes = {},
   policyVersion = "",
   scope = "",
-}: Principal): PrincipalProtobuf => ({
-  id,
-  roles,
-  attr: attributes,
-  policyVersion,
-  scope,
-});
+}: Principal): PrincipalProtobuf {
+  return {
+    id,
+    roles,
+    attr: attributes,
+    policyVersion,
+    scope,
+  };
+}
 
-const resourceCheckToProtobuf = ({
+function resourceCheckToProtobuf({
   resource,
   actions,
-}: ResourceCheck): CheckResourcesRequest_ResourceEntry => ({
-  resource: resourceToProtobuf(resource),
-  actions,
-});
+}: ResourceCheck): CheckResourcesRequest_ResourceEntry {
+  return {
+    resource: resourceToProtobuf(resource),
+    actions,
+  };
+}
 
-const resourceToProtobuf = ({
+function resourceToProtobuf({
   kind,
   id,
   attributes = {},
   policyVersion = "",
   scope = "",
-}: Resource): ResourceProtobuf => ({
-  kind,
-  id,
-  attr: attributes,
-  policyVersion,
-  scope,
-});
+}: Resource): ResourceProtobuf {
+  return {
+    kind,
+    id,
+    attr: attributes,
+    policyVersion,
+    scope,
+  };
+}
 
-const auxDataToProtobuf = ({ jwt }: AuxData): AuxDataProtobuf => ({
-  jwt: jwt && jwtToProtobuf(jwt),
-});
+function auxDataToProtobuf({ jwt }: AuxData): AuxDataProtobuf {
+  return {
+    jwt: jwt && jwtToProtobuf(jwt),
+  };
+}
 
-const jwtToProtobuf = ({ token, keySetId = "" }: JWT): AuxData_JWT => ({
-  token,
-  keySetId,
-});
+function jwtToProtobuf({ token, keySetId = "" }: JWT): AuxData_JWT {
+  return {
+    token,
+    keySetId,
+  };
+}
 
-export const deleteSchemasRequestToProtobuf = ({
+export function deleteSchemasRequestToProtobuf({
   ids,
-}: DeleteSchemasRequest): DeleteSchemaRequest => ({
-  id: ids,
-});
+}: DeleteSchemasRequest): DeleteSchemaRequest {
+  return {
+    id: ids,
+  };
+}
 
-export const disablePoliciesRequestToProtobuf = ({
+export function disablePoliciesRequestToProtobuf({
   ids,
-}: DisablePoliciesRequest): DisablePolicyRequest => ({
-  id: ids,
-});
+}: DisablePoliciesRequest): DisablePolicyRequest {
+  return {
+    id: ids,
+  };
+}
 
-export const enablePoliciesRequestToProtobuf = ({
+export function enablePoliciesRequestToProtobuf({
   ids,
-}: EnablePoliciesRequest): EnablePolicyRequest => ({
-  id: ids,
-});
+}: EnablePoliciesRequest): EnablePolicyRequest {
+  return {
+    id: ids,
+  };
+}
 
-export const getPoliciesRequestToProtobuf = ({
+export function getPoliciesRequestToProtobuf({
   ids,
-}: GetPoliciesRequest): GetPolicyRequest => ({
-  id: ids,
-});
+}: GetPoliciesRequest): GetPolicyRequest {
+  return {
+    id: ids,
+  };
+}
 
-export const getSchemasRequestToProtobuf = ({
+export function getSchemasRequestToProtobuf({
   ids,
-}: GetSchemasRequest): GetSchemaRequest => ({
-  id: ids,
-});
+}: GetSchemasRequest): GetSchemaRequest {
+  return {
+    id: ids,
+  };
+}
 
-export const listPoliciesRequestToProtobuf = ({
+export function listPoliciesRequestToProtobuf({
   includeDisabled = false,
   nameRegexp = "",
   scopeRegexp = "",
   versionRegexp = "",
-}: ListPoliciesRequest): ListPoliciesRequestProtobuf => ({
-  includeDisabled,
-  nameRegexp,
-  scopeRegexp,
-  versionRegexp,
-});
+}: ListPoliciesRequest): ListPoliciesRequestProtobuf {
+  return {
+    includeDisabled,
+    nameRegexp,
+    scopeRegexp,
+    versionRegexp,
+  };
+}
 
-export const planResourcesRequestToProtobuf = ({
+export function planResourcesRequestToProtobuf({
   principal,
   resource,
   action,
   auxData,
   includeMetadata = false,
   requestId = uuidv4(),
-}: PlanResourcesRequest): PlanResourcesRequestProtobuf => ({
-  principal: principalToProtobuf(principal),
-  resource: resourceQueryToProtobuf(resource),
-  action,
-  auxData: auxData && auxDataToProtobuf(auxData),
-  includeMeta: includeMetadata,
-  requestId,
-});
+}: PlanResourcesRequest): PlanResourcesRequestProtobuf {
+  return {
+    principal: principalToProtobuf(principal),
+    resource: resourceQueryToProtobuf(resource),
+    action,
+    auxData: auxData && auxDataToProtobuf(auxData),
+    includeMeta: includeMetadata,
+    requestId,
+  };
+}
 
-const resourceQueryToProtobuf = ({
+function resourceQueryToProtobuf({
   kind,
   attributes = {},
   policyVersion = "",
   scope = "",
-}: ResourceQuery): PlanResourcesInput_Resource => ({
-  kind,
-  attr: attributes,
-  policyVersion,
-  scope,
-});
+}: ResourceQuery): PlanResourcesInput_Resource {
+  return {
+    kind,
+    attr: attributes,
+    policyVersion,
+    scope,
+  };
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -87,7 +87,7 @@ export class NotOK extends Error {
   }
 }
 
-const code = (error: unknown): Status => {
+function code(error: unknown): Status {
   if (
     has(error, "code") &&
     typeof error.code === "number" &&
@@ -97,21 +97,22 @@ const code = (error: unknown): Status => {
   }
 
   throw new Error("Error does not include expected code");
-};
+}
 
-const details = (error: unknown): string => {
+function details(error: unknown): string {
   if (has(error, "message") && typeof error.message === "string") {
     return error.message;
   }
 
   throw new Error("Error does not include expected details");
-};
+}
 
-const has = <K extends string>(
+function has<K extends string>(
   object: unknown,
   property: K,
-): object is Record<K, unknown> =>
-  !!object && Object.prototype.hasOwnProperty.call(object, property);
+): object is Record<K, unknown> {
+  return !!object && Object.prototype.hasOwnProperty.call(object, property);
+}
 
 /**
  * Error thrown when input fails schema validation, if the {@link @cerbos/core#Client} is configured with {@link @cerbos/core#Options.onValidationError | onValidationError} set to `"throw"`.

--- a/packages/core/src/types/external/Match.ts
+++ b/packages/core/src/types/external/Match.ts
@@ -15,29 +15,33 @@ export type Match = MatchAll | MatchAny | MatchNone | MatchExpr;
  *
  * @public
  */
-export const matchIsMatchAll = (match: Match): match is MatchAll =>
-  "all" in match;
+export function matchIsMatchAll(match: Match): match is MatchAll {
+  return "all" in match;
+}
 
 /**
  * Type guard to check if a {@link Match} is a {@link MatchAny}.
  *
  * @public
  */
-export const matchIsMatchAny = (match: Match): match is MatchAny =>
-  "any" in match;
+export function matchIsMatchAny(match: Match): match is MatchAny {
+  return "any" in match;
+}
 
 /**
  * Type guard to check if a {@link Match} is a {@link MatchNone}.
  *
  * @public
  */
-export const matchIsMatchNone = (match: Match): match is MatchNone =>
-  "none" in match;
+export function matchIsMatchNone(match: Match): match is MatchNone {
+  return "none" in match;
+}
 
 /**
  * Type guard to check if a {@link Match} is a {@link MatchExpr}.
  *
  * @public
  */
-export const matchIsMatchExpr = (match: Match): match is MatchExpr =>
-  "expr" in match;
+export function matchIsMatchExpr(match: Match): match is MatchExpr {
+  return "expr" in match;
+}

--- a/packages/core/src/types/external/Policy.ts
+++ b/packages/core/src/types/external/Policy.ts
@@ -19,32 +19,39 @@ export type Policy =
  *
  * @public
  */
-export const policyIsDerivedRoles = (policy: Policy): policy is DerivedRoles =>
-  "derivedRoles" in policy;
+export function policyIsDerivedRoles(policy: Policy): policy is DerivedRoles {
+  return "derivedRoles" in policy;
+}
 
 /**
  * Type guard to check if a {@link Policy} is a set of {@link ExportVariables}.
  *
  * @public
  */
-export const policyIsExportVariables = (
+export function policyIsExportVariables(
   policy: Policy,
-): policy is ExportVariables => "exportVariables" in policy;
+): policy is ExportVariables {
+  return "exportVariables" in policy;
+}
 
 /**
  * Type guard to check if a {@link Policy} is a {@link PrincipalPolicy}.
  *
  * @public
  */
-export const policyIsPrincipalPolicy = (
+export function policyIsPrincipalPolicy(
   policy: Policy,
-): policy is PrincipalPolicy => "principalPolicy" in policy;
+): policy is PrincipalPolicy {
+  return "principalPolicy" in policy;
+}
 
 /**
  * Type guard to check if a {@link Policy} is a {@link ResourcePolicy}.
  *
  * @public
  */
-export const policyIsResourcePolicy = (
+export function policyIsResourcePolicy(
   policy: Policy,
-): policy is ResourcePolicy => "resourcePolicy" in policy;
+): policy is ResourcePolicy {
+  return "resourcePolicy" in policy;
+}

--- a/packages/core/src/types/internal.ts
+++ b/packages/core/src/types/internal.ts
@@ -2,5 +2,6 @@ export type OmitFromEach<T, K extends string> = T extends unknown
   ? Omit<T, K>
   : never;
 
-export const isObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+export function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -11,7 +11,6 @@ import type {
   _Request,
   _Response,
   _Service,
-  _Transport,
 } from "@cerbos/core";
 import { Client, NotOK } from "@cerbos/core";
 import { btoa } from "abab";
@@ -108,12 +107,7 @@ export class HTTP extends Client {
    * ```
    */
   public constructor(url: string, options: Options = {}) {
-    const transport: _Transport = async (
-      service,
-      rpc,
-      request,
-      adminCredentials,
-    ) => {
+    super(async (service, rpc, request, adminCredentials) => {
       const { method, path, requestType, responseType, serializeRequest } =
         services[service][rpc] as Endpoint<typeof service, typeof rpc>; // https://github.com/microsoft/TypeScript/issues/30581
 
@@ -136,9 +130,7 @@ export class HTTP extends Client {
       }
 
       return responseType.fromJSON(await response.json());
-    };
-
-    super(transport, options);
+    }, options);
   }
 }
 
@@ -254,10 +246,10 @@ const services: Services = {
   },
 };
 
-const headers = (
+function headers(
   { headers: optionalHeaders, playgroundInstance }: Options,
   adminCredentials: AdminCredentials | undefined,
-): Headers => {
+): Headers {
   const headers = new Headers(
     typeof optionalHeaders === "function" ? optionalHeaders() : optionalHeaders,
   );
@@ -282,4 +274,4 @@ const headers = (
   }
 
   return headers;
-};
+}

--- a/packages/test/src/Client.test.ts
+++ b/packages/test/src/Client.test.ts
@@ -44,10 +44,12 @@ import {
   ports as serverPorts,
 } from "./servers";
 
-const readPEM = (filename: string): string =>
-  readFileSync(resolve(__dirname, "../servers/tmp/certificates", filename), {
-    encoding: "utf-8",
-  });
+function readPEM(filename: string): string {
+  return readFileSync(
+    resolve(__dirname, "../servers/tmp/certificates", filename),
+    { encoding: "utf-8" },
+  );
+}
 
 describe("Client", () => {
   let ports: Ports;

--- a/packages/test/src/helpers.ts
+++ b/packages/test/src/helpers.ts
@@ -5,7 +5,7 @@ import type {
   ReadableSpan,
 } from "@opentelemetry/sdk-trace-base";
 
-export const buildResultsForResources = ({
+export function buildResultsForResources({
   id,
   policyVersions,
   scopes,
@@ -13,19 +13,20 @@ export const buildResultsForResources = ({
   id: string;
   policyVersions: string[];
   scopes: string[];
-}): CheckResourcesResult[] =>
-  ["document", "image"].flatMap((kind) =>
+}): CheckResourcesResult[] {
+  return ["document", "image"].flatMap((kind) =>
     policyVersions.flatMap((policyVersion) =>
       scopes.map((scope) =>
         buildResult({ resource: { kind, id, policyVersion, scope } }),
       ),
     ),
   );
+}
 
-export const buildResult = (
+export function buildResult(
   result: Partial<ConstructorParameters<typeof CheckResourcesResult>[0]>,
-): CheckResourcesResult =>
-  new CheckResourcesResult({
+): CheckResourcesResult {
+  return new CheckResourcesResult({
     resource: {
       kind: "document",
       id: "1",
@@ -38,19 +39,21 @@ export const buildResult = (
     outputs: [],
     ...result,
   });
+}
 
-export const shuffle = <T>(values: T[]): T[] =>
-  values
+export function shuffle<T>(values: T[]): T[] {
+  return values
     .map((value) => ({ value, order: Math.random() }))
     .sort((a, b) => a.order - b.order)
     .map(({ value }) => value);
+}
 
 type Result<T> = { value: T } | { error: unknown };
 
-export const captureSpan = async <T>(
+export async function captureSpan<T>(
   spanExporter: InMemorySpanExporter,
   fn: () => Promise<T>,
-): Promise<[Result<T>, ReadableSpan]> => {
+): Promise<[Result<T>, ReadableSpan]> {
   const parentSpan = trace
     .getTracer("@cerbos/test")
     .startSpan("cerbos.test.parent");
@@ -77,4 +80,4 @@ export const captureSpan = async <T>(
   }
 
   return [result, childSpan];
-};
+}

--- a/packages/test/src/servers.ts
+++ b/packages/test/src/servers.ts
@@ -8,8 +8,9 @@ const execFile = promisify(execFileCallback);
 
 export const cerbosVersion = process.env["CERBOS_VERSION"] ?? "0.16.0";
 
-export const cerbosVersionIsAtLeast = (version: string): boolean =>
-  semverGte(cerbosVersion, `${version}-prerelease`);
+export function cerbosVersionIsAtLeast(version: string): boolean {
+  return semverGte(cerbosVersion, `${version}-prerelease`);
+}
 
 export interface Ports {
   grpc: {
@@ -35,7 +36,7 @@ interface DockerComposeContainer {
     | null;
 }
 
-export const ports = async (): Promise<Ports> => {
+export async function ports(): Promise<Ports> {
   const { stdout } = await execFile("docker", [
     "compose",
     "--file",
@@ -60,13 +61,13 @@ export const ports = async (): Promise<Ports> => {
       mutable: port(output, "mutable", 3592),
     },
   };
-};
+}
 
-const port = (
+function port(
   containers: DockerComposeContainer[],
   service: string,
   targetPort: number,
-): number => {
+): number {
   const container = containers.find(
     (container) => container.Service === service,
   );
@@ -86,4 +87,4 @@ const port = (
   }
 
   return publisher.PublishedPort;
-};
+}


### PR DESCRIPTION
Declaring functions with `export const foo = () => { ... };` causes `foo` to be documented as a variable, with no details about the parameters or return type. Using `export function foo() { ... }` causes `foo` to be documented correctly. This PR enables the [`func-style`](https://eslint.org/docs/latest/rules/func-style) linter rule to enforce the use of the latter style.