### PR TITLE
chore(deps): Remove `abab`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2073,11 +2073,6 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
-    },
     "node_modules/acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
@@ -7699,7 +7694,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cerbos/core": "^0.12.0",
-        "abab": "^2.0.6",
         "qs": "^6.11.2"
       },
       "devDependencies": {

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Removed
+
+- Dependency on [abab](https://github.com/jsdom/abab), which is no longer necessary since dropping support for Node.js 14. The `btoa` global function is [supported in Node.js 16+ and all browsers](https://developer.mozilla.org/en-US/docs/Web/API/btoa#browser_compatibility).
 
 ## [0.13.0] - 2023-07-18
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -27,7 +27,6 @@
   ],
   "dependencies": {
     "@cerbos/core": "^0.12.0",
-    "abab": "^2.0.6",
     "qs": "^6.11.2"
   },
   "devDependencies": {

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -13,7 +13,6 @@ import type {
   _Service,
 } from "@cerbos/core";
 import { Client, NotOK } from "@cerbos/core";
-import { btoa } from "abab";
 import { stringify as queryStringify } from "qs";
 
 import {


### PR DESCRIPTION
This PR removes `@cerbos/http`'s dependency on [abab](https://github.com/jsdom/abab), which is no longer necessary since dropping support for Node.js 14. The `btoa` global function is [supported in Node.js 16+ and all browsers](https://developer.mozilla.org/en-US/docs/Web/API/btoa#browser_compatibility).