### PR TITLE
chore(test): Fix test flakiness by only publishing ports on IPv6

### DIFF
--- a/packages/test/servers/docker-compose.yaml
+++ b/packages/test/servers/docker-compose.yaml
@@ -20,8 +20,12 @@ services:
     healthcheck:
       interval: 2s
     ports:
-      - 3592
-      - 3593
+      - protocol: tcp
+        target: 3592
+        host_ip: "::1"
+      - protocol: tcp
+        target: 3593
+        host_ip: "::1"
     user: ${USER}
     volumes:
       - type: bind
@@ -72,7 +76,9 @@ services:
         - healthcheck
         - --ping
     ports:
-      - 3593
+      - protocol: tcp
+        target: 3593
+        host_ip: "::1"
     volumes:
       - type: bind
         source: tmp/certificates
@@ -126,4 +132,6 @@ services:
       retries: 3
       start_period: 5s
     ports:
-      - 16685
+      - protocol: tcp
+        target: 16685
+        host_ip: "::1"


### PR DESCRIPTION
There's [a bug in Docker](https://github.com/moby/moby/issues/42442
) where if you publish container ports to a random host port, the host port isn't guaranteed to be the same for IPv4 and IPv6. Worse, the same port can be used for IPv4 on one container and IPv6 on another.

This is why our tests have been failing intermittently - the client in the test can connect to the wrong server, because we may have read the IPv4 port from the `docker compose ps` output but then connected via IPv6 to a completely different service.

This PR fixes the flakiness by only binding the services to the IPv6 loopback address on the host.