### PR TITLE
fix: Allow promises of binary data in embedded `Source` type

### DIFF
--- a/docs/embedded.source.md
+++ b/docs/embedded.source.md
@@ -9,5 +9,5 @@ WebAssembly binary code of an embedded policy decision point bundle (or an HTTP 
 **Signature:**
 
 ```typescript
-export type Source = ArrayBufferView | ArrayBuffer | Response | Promise<Response>;
+export type Source = ArrayBufferView | ArrayBuffer | Response | Promise<ArrayBufferView | ArrayBuffer | Response>;
 ```

--- a/packages/embedded/CHANGELOG.md
+++ b/packages/embedded/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Allow promises of binary data in [Source](../../docs/embedded.source.md) type ([#824](https://github.com/cerbos/cerbos-sdk-javascript/pull/824))
 
 ## [0.6.1] - 2024-01-11
 

--- a/packages/embedded/src/client.ts
+++ b/packages/embedded/src/client.ts
@@ -13,7 +13,7 @@ export type Source =
   | ArrayBufferView
   | ArrayBuffer
   | Response
-  | Promise<Response>;
+  | Promise<ArrayBufferView | ArrayBuffer | Response>;
 
 /**
  * Options for creating a new {@link Embedded} client.

--- a/packages/test/src/Embedded.test.ts
+++ b/packages/test/src/Embedded.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
 import { resolve } from "path";
 
 import type { CheckResourcesRequest } from "@cerbos/core";
@@ -15,7 +15,7 @@ import { describe, expect, it } from "vitest";
 describe("Embedded", () => {
   describe("cerbos", () => {
     const client = new Embedded(
-      readFileSync(resolve(__dirname, "../servers/policies.wasm")),
+      readFile(resolve(__dirname, "../servers/policies.wasm")),
       {
         decodeJWTPayload: ({ token }): DecodedJWTPayload =>
           UnsecuredJWT.decode(token).payload as DecodedJWTPayload,


### PR DESCRIPTION
We `await` the embedded client's source, so it's valid to pass in `Promise<ArrayBuffer[View]>`.

https://github.com/cerbos/cerbos-sdk-javascript/blob/a04a0ffc83f0c9987bf4fb09196a613503cf3e38/packages/embedded/src/client.ts#L121

However, the only promise our `Source` type currently allows is one resolving to `Response`.

https://github.com/cerbos/cerbos-sdk-javascript/blob/a04a0ffc83f0c9987bf4fb09196a613503cf3e38/packages/embedded/src/client.ts#L12-L16

This PR fixes the `Source` type to allow promises of binary data, not just HTTP responses.