### PR TITLE
enhancement: Default `ClientWithPrincipal` type parameter to `Client`

### DIFF
--- a/docs/core.clientwithprincipal.md
+++ b/docs/core.clientwithprincipal.md
@@ -9,7 +9,7 @@ A client instance with a pre-specified principal.
 **Signature:**
 
 ```typescript
-export declare class ClientWithPrincipal<ClientType extends Client> 
+export declare class ClientWithPrincipal<ClientType extends Client = Client> 
 ```
 
 ## Remarks

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868))
+- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868), [#877](https://github.com/cerbos/cerbos-sdk-javascript/pull/877))
 
 ### Changed
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -978,7 +978,7 @@ export abstract class Client {
  *
  * @public
  */
-export class ClientWithPrincipal<ClientType extends Client> {
+export class ClientWithPrincipal<ClientType extends Client = Client> {
   /** @internal */
   public constructor(
     /**

--- a/packages/embedded/CHANGELOG.md
+++ b/packages/embedded/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868))
+- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868), [#877](https://github.com/cerbos/cerbos-sdk-javascript/pull/877))
 
 ### Changed
 

--- a/packages/grpc/CHANGELOG.md
+++ b/packages/grpc/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868))
+- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868), [#877](https://github.com/cerbos/cerbos-sdk-javascript/pull/877))
 
 ### Changed
 

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868))
+- [`Client.withPrincipal`](../../docs/core.client.withprincipal.md) method to create a client instance with a pre-specified principal ([#868](https://github.com/cerbos/cerbos-sdk-javascript/pull/868), [#877](https://github.com/cerbos/cerbos-sdk-javascript/pull/877))
 
 ### Changed
 


### PR DESCRIPTION
I realised from #876 that it's kinda annoying if you have to explicitly specify the type parameter of `ClientWithPrincipal`, so this PR defaults it to `Client` to allow it to be omitted.