### PR TITLE
chore: Use individually-exported semantic attributes values to improve minification

### DIFF
--- a/packages/grpc/tsconfig.protobuf.json
+++ b/packages/grpc/tsconfig.protobuf.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../tsconfig.base.json",
-  "include": ["src/protobuf"],
-  "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src",
-    "tsBuildInfoFile": "lib/grpc.protobuf.tsbuildinfo"
-  }
-}

--- a/packages/opentelemetry/CHANGELOG.md
+++ b/packages/opentelemetry/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Prevent importing package internals ([#867](https://github.com/cerbos/cerbos-sdk-javascript/pull/867))
 
+- Use individually-exported semantic attributes values to improve minification ([#889](https://github.com/cerbos/cerbos-sdk-javascript/pull/889))
+
 ## [0.4.4] - 2024-04-08
 
 ### Changed

--- a/packages/opentelemetry/changelog.yaml
+++ b/packages/opentelemetry/changelog.yaml
@@ -5,6 +5,9 @@ unreleased:
     - summary: Prevent importing package internals
       pull: 867
 
+    - summary: Use individually-exported semantic attributes values to improve minification
+      pull: 889
+
 releases:
   - version: 0.4.4
     date: 2024-04-08

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -34,7 +34,12 @@ import type {
   Instrumentation,
   InstrumentationConfig,
 } from "@opentelemetry/instrumentation";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+import {
+  SEMATTRS_RPC_GRPC_STATUS_CODE,
+  SEMATTRS_RPC_METHOD,
+  SEMATTRS_RPC_SERVICE,
+  SEMATTRS_RPC_SYSTEM,
+} from "@opentelemetry/semantic-conventions";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires -- Can't import package.json because it is outside of the project's rootDir
 const { name, version } = require("../package.json") as {
@@ -110,9 +115,9 @@ export class CerbosInstrumentation implements Instrumentation {
         const serviceName = serviceNames[service];
         const methodName = rpcMethodName(rpc);
         const attributes: Attributes = {
-          [SemanticAttributes.RPC_SYSTEM]: "grpc",
-          [SemanticAttributes.RPC_SERVICE]: serviceName,
-          [SemanticAttributes.RPC_METHOD]: methodName,
+          [SEMATTRS_RPC_SYSTEM]: "grpc",
+          [SEMATTRS_RPC_SERVICE]: serviceName,
+          [SEMATTRS_RPC_METHOD]: methodName,
         };
 
         const span = this.tracer.startSpan(`${serviceName}/${methodName}`, {
@@ -138,7 +143,7 @@ export class CerbosInstrumentation implements Instrumentation {
             headers,
           )) as _Response<Service, RPC>;
 
-          attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE] = 0;
+          attributes[SEMATTRS_RPC_GRPC_STATUS_CODE] = 0;
 
           return response;
         } catch (error) {
@@ -149,7 +154,7 @@ export class CerbosInstrumentation implements Instrumentation {
             attributes["cerbos.error"] = error.message;
 
             if (error instanceof NotOK) {
-              attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE] = error.code;
+              attributes[SEMATTRS_RPC_GRPC_STATUS_CODE] = error.code;
             }
           }
 

--- a/private/test/src/CerbosInstrumentation.test.ts
+++ b/private/test/src/CerbosInstrumentation.test.ts
@@ -19,7 +19,12 @@ import {
   SimpleSpanProcessor,
 } from "@opentelemetry/sdk-trace-base";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
+import {
+  SEMATTRS_RPC_GRPC_STATUS_CODE,
+  SEMATTRS_RPC_METHOD,
+  SEMATTRS_RPC_SERVICE,
+  SEMATTRS_RPC_SYSTEM,
+} from "@opentelemetry/semantic-conventions";
 import { UnsecuredJWT } from "jose";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
@@ -125,10 +130,10 @@ describe("CerbosInstrumentation", () => {
         );
 
         const attributes: Attributes = {
-          [SemanticAttributes.RPC_SYSTEM]: "grpc",
-          [SemanticAttributes.RPC_SERVICE]: "cerbos.svc.v1.CerbosService",
-          [SemanticAttributes.RPC_METHOD]: "CheckResources",
-          [SemanticAttributes.RPC_GRPC_STATUS_CODE]: 0,
+          [SEMATTRS_RPC_SYSTEM]: "grpc",
+          [SEMATTRS_RPC_SERVICE]: "cerbos.svc.v1.CerbosService",
+          [SEMATTRS_RPC_METHOD]: "CheckResources",
+          [SEMATTRS_RPC_GRPC_STATUS_CODE]: 0,
         };
 
         expect(result).toEqual({ value: false });
@@ -158,13 +163,13 @@ describe("CerbosInstrumentation", () => {
               kind: SpanKindProto.SPAN_KIND_SERVER,
               attributes: expect.arrayContaining([
                 {
-                  key: SemanticAttributes.RPC_SYSTEM,
+                  key: SEMATTRS_RPC_SYSTEM,
                   value: {
                     value: { $case: "stringValue", stringValue: "grpc" },
                   },
                 },
                 {
-                  key: SemanticAttributes.RPC_SERVICE,
+                  key: SEMATTRS_RPC_SERVICE,
                   value: {
                     value: {
                       $case: "stringValue",
@@ -173,7 +178,7 @@ describe("CerbosInstrumentation", () => {
                   },
                 },
                 {
-                  key: SemanticAttributes.RPC_METHOD,
+                  key: SEMATTRS_RPC_METHOD,
                   value: {
                     value: {
                       $case: "stringValue",
@@ -182,7 +187,7 @@ describe("CerbosInstrumentation", () => {
                   },
                 },
                 {
-                  key: SemanticAttributes.RPC_GRPC_STATUS_CODE,
+                  key: SEMATTRS_RPC_GRPC_STATUS_CODE,
                   value: {
                     value: { $case: "intValue", intValue: "0" },
                   },
@@ -213,10 +218,10 @@ describe("CerbosInstrumentation", () => {
           );
 
           const attributes: Attributes = {
-            [SemanticAttributes.RPC_SYSTEM]: "grpc",
-            [SemanticAttributes.RPC_SERVICE]: "cerbos.svc.v1.CerbosService",
-            [SemanticAttributes.RPC_METHOD]: "CheckResources",
-            [SemanticAttributes.RPC_GRPC_STATUS_CODE]: Status.INVALID_ARGUMENT,
+            [SEMATTRS_RPC_SYSTEM]: "grpc",
+            [SEMATTRS_RPC_SERVICE]: "cerbos.svc.v1.CerbosService",
+            [SEMATTRS_RPC_METHOD]: "CheckResources",
+            [SEMATTRS_RPC_GRPC_STATUS_CODE]: Status.INVALID_ARGUMENT,
             "cerbos.error": invalidArgumentDetails as unknown as AttributeValue,
           };
 


### PR DESCRIPTION
This PR resolves a deprecation warning introduced in #836, from https://github.com/open-telemetry/opentelemetry-js/pull/4298

>Use the `SEMATTRS_XXXXX` constants rather than the `SemanticAttributes.XXXXX` for bundle minification.