### PR TITLE
chore: Group devDependencies updates and reduce update frequency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,9 +3,9 @@
   "extends": [
     ":dependencyDashboard",
     ":gitSignOff",
-    ":prConcurrentLimit10",
-    ":prHourlyLimit2",
+    ":prConcurrentLimitNone",
     "npm:unpublishSafe",
+    "schedule:weekly",
     "workarounds:all"
   ],
   "packageRules": [
@@ -16,17 +16,22 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
+      "groupName": "devDependencies",
       "rangeStrategy": "pin",
       "semanticCommitScope": "deps-dev"
     },
     {
-      "matchManagers": ["nodenv", "npm"],
-      "matchPackageNames": ["node", "pnpm"],
-      "matchFiles": [".node-version", "package.json"],
+      "matchManagers": ["nodenv"],
+      "groupName": "devDependencies",
       "rangeStrategy": "pin",
-      "semanticCommitScope": "deps-dev",
-      "versioning": "npm",
-      "extractVersion": "^v(?<version>.*)$"
+      "semanticCommitScope": "deps-dev"
+    },
+    {
+      "matchFiles": ["package.json"],
+      "matchPackageNames": ["node", "pnpm"],
+      "groupName": "devDependencies",
+      "rangeStrategy": "pin",
+      "semanticCommitScope": "deps-dev"
     },
     {
       "matchPackageNames": ["@types/node", "long", "protobufjs"],
@@ -34,16 +39,12 @@
       "enabled": false
     },
     {
-      "matchPackagePrefixes": ["@microsoft/api-"],
-      "groupName": "docs"
-    },
-    {
-      "matchPackagePrefixes": ["@typescript-eslint/", "eslint", "prettier"],
-      "groupName": "lint"
+      "matchPackageNames": ["@grpc/grpc-js", "long", "protobufjs"],
+      "groupName": "gRPC"
     },
     {
       "matchPackagePrefixes": ["@opentelemetry/"],
-      "groupName": "opentelemetry"
+      "groupName": "OpenTelemetry"
     }
   ],
   "postUpdateOptions": ["pnpmDedupe"],


### PR DESCRIPTION
Renovate is getting a bit too noisy so this PR configures it to group all updates to devDependencies into a single PR, and schedules updates for Mondays rather than having them coming in constantly.

We haven't been getting automated updates for pnpm or Node.js so hopefully this fixes that as well.