### PR TITLE
chore: Handle edge cases around preparing initial releases

### DIFF
--- a/private/scripts/src/utils/releases.ts
+++ b/private/scripts/src/utils/releases.ts
@@ -115,13 +115,15 @@ async function prepareRelease(
     for (const [dependency, newVersion] of pkg.dependenciesToBump) {
       pkg.manifest.dependencies[dependency] = `^${newVersion}`;
 
-      (pkg.unreleased.bumped ??= {})[dependency] = {
-        to: newVersion,
-        pull: pullRequest,
-      };
+      if (pkg.changelog.releases?.length) {
+        (pkg.unreleased.bumped ??= {})[dependency] = {
+          to: newVersion,
+          pull: pullRequest,
+        };
 
-      (pkg.changelog.references ??= {})[dependency] =
-        `../${dependency.replace("@cerbos/", "")}/README.md`;
+        (pkg.changelog.references ??= {})[dependency] =
+          `../${dependency.replace("@cerbos/", "")}/README.md`;
+      }
     }
   }
 

--- a/private/scripts/src/utils/releases.ts
+++ b/private/scripts/src/utils/releases.ts
@@ -114,10 +114,14 @@ async function prepareRelease(
   if (pkg.manifest.dependencies) {
     for (const [dependency, newVersion] of pkg.dependenciesToBump) {
       pkg.manifest.dependencies[dependency] = `^${newVersion}`;
+
       (pkg.unreleased.bumped ??= {})[dependency] = {
         to: newVersion,
         pull: pullRequest,
       };
+
+      (pkg.changelog.references ??= {})[dependency] =
+        `../${dependency.replace("@cerbos/", "")}/README.md`;
     }
   }
 


### PR DESCRIPTION
This PR handles a couple of edge cases in the release preparation script

- If a changelog doesn't have a reference for an inter-package dependency, add it automatically (otherwise the script fails after it adds a changelog entry bumping that dependency).
- Don't add a changelog entries bumping inter-package dependencies to initial releases (it makes no sense to have a "Changed" section when there is no previous release to have changed from).