### PR TITLE
chore(ci): Require full test matrix on scheduled builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
   test:
     name: Test (${{ matrix.title }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ !matrix.required }}
+    continue-on-error: ${{ github.event_name != 'schedule' && !matrix.required }}
     needs:
       - test-matrix
     strategy:


### PR DESCRIPTION
This PR makes all entries in the test matrix required for scheduled builds, so that we get a notification in Slack if the prerelease builds start failing.