### PR TITLE
fix: Cancel unused response bodies

### DIFF
--- a/packages/embedded/CHANGELOG.md
+++ b/packages/embedded/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Cancel unused response bodies ([#956](https://github.com/cerbos/cerbos-sdk-javascript/pull/956))
 
 ## [0.7.2] - 2024-05-15
 

--- a/packages/embedded/changelog.yaml
+++ b/packages/embedded/changelog.yaml
@@ -1,3 +1,10 @@
+unreleased:
+  type: patch
+
+  changed:
+    - summary: Cancel unused response bodies
+      pull: 956
+
 releases:
   - version: 0.7.2
     date: 2024-05-15

--- a/packages/embedded/src/bundle.ts
+++ b/packages/embedded/src/bundle.ts
@@ -10,6 +10,7 @@ import type {
 } from "./loader";
 import { CheckResourcesRequest } from "./protobuf/cerbos/request/v1/request";
 import { CheckResourcesResponse } from "./protobuf/cerbos/response/v1/response";
+import { cancelBody } from "./response";
 import type { Allocator } from "./slice";
 import { Slice } from "./slice";
 
@@ -170,6 +171,7 @@ async function instantiateStreaming(
   imports: WebAssembly.Imports,
 ): Promise<Exports> {
   if (!response.ok) {
+    cancelBody(response);
     throw new Error(
       `Failed to download from ${response.url}: HTTP ${response.status}`,
     );

--- a/packages/embedded/src/loader.ts
+++ b/packages/embedded/src/loader.ts
@@ -3,6 +3,7 @@ import { _setErrorNameAndStack } from "@cerbos/core";
 
 import { Bundle, download } from "./bundle";
 import { constrainAutoUpdateInterval } from "./interval";
+import { cancelBody } from "./response";
 import { Transport } from "./transport";
 
 type LoadResult =
@@ -437,6 +438,7 @@ export class AutoUpdatingLoader extends Loader {
     const response = await download(this.url, request);
 
     if (response.status === 304) {
+      cancelBody(response);
       throw notModified;
     }
 

--- a/packages/embedded/src/response.ts
+++ b/packages/embedded/src/response.ts
@@ -1,0 +1,5 @@
+export function cancelBody(response: Response): void {
+  response.body?.cancel().catch(() => {
+    // ignore failure to cancel
+  });
+}

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-No notable changes.
+### Changed
+
+- Cancel unused response bodies ([#956](https://github.com/cerbos/cerbos-sdk-javascript/pull/956))
 
 ## [0.19.0] - 2024-05-15
 

--- a/packages/http/changelog.yaml
+++ b/packages/http/changelog.yaml
@@ -1,3 +1,10 @@
+unreleased:
+  type: patch
+
+  changed:
+    - summary: Cancel unused response bodies
+      pull: 956
+
 releases:
   - version: 0.19.0
     date: 2024-05-15

--- a/packages/http/src/transport.ts
+++ b/packages/http/src/transport.ts
@@ -284,6 +284,10 @@ export class Transport implements _Transport {
         yield responseType.fromJSON(result);
       }
     } catch (error) {
+      response.body?.cancel().catch(() => {
+        // ignore failure to cancel
+      });
+
       abortHandler.throwIfAborted();
 
       if (error instanceof NotOK) {


### PR DESCRIPTION
Undici does not conform with the Fetch Standard when it comes to garbage collection of responses ([details](https://github.com/nodejs/undici#garbage-collection)), so to avoid leaking connections it is important to either consume or cancel the response body stream.

This PR adds response body cancellations to the code paths that do not fully consume the stream.