### PR TITLE
chore: Automatically clear mocks between tests

### DIFF
--- a/private/test/src/matrix-react/cerbos-provider.test.tsx
+++ b/private/test/src/matrix-react/cerbos-provider.test.tsx
@@ -80,36 +80,41 @@ function App({ children }: PropsWithChildren<object>): ReactElement {
 
 describe("<CerbosProvider>", () => {
   const container = document.createElement("div");
+  let rerender: () => void;
 
-  const { rerender } = renderHook(useCerbos, { wrapper: App, container });
   it("correctly initializes ClientWithPrincipal", () => {
-    expect(client.withPrincipal).toHaveBeenLastCalledWith(
+    ({ rerender } = renderHook(useCerbos, { wrapper: App, container }));
+
+    expect(client.withPrincipal).toHaveBeenCalledOnce();
+    expect(client.withPrincipal).toHaveBeenCalledWith(
       getPrincipal(false),
       getAuxData(false),
     );
-    expect(client.withPrincipal).toHaveBeenCalledTimes(1);
   });
 
   it("re-initializes ClientWithPrincipal when principal changes", async () => {
     await userEvent.click(getByText(container, "switch user"));
-    expect(client.withPrincipal).toHaveBeenLastCalledWith(
+
+    expect(client.withPrincipal).toHaveBeenCalledOnce();
+    expect(client.withPrincipal).toHaveBeenCalledWith(
       getPrincipal(true),
       getAuxData(false),
     );
-    expect(client.withPrincipal).toHaveBeenCalledTimes(2);
   });
 
   it("re-initializes ClientWithPrincipal when auxData changes", async () => {
     await userEvent.click(getByText(container, "switch aux data"));
-    expect(client.withPrincipal).toHaveBeenLastCalledWith(
+
+    expect(client.withPrincipal).toHaveBeenCalledOnce();
+    expect(client.withPrincipal).toHaveBeenCalledWith(
       getPrincipal(true),
       getAuxData(true),
     );
-    expect(client.withPrincipal).toHaveBeenCalledTimes(3);
   });
 
   it("re-renders without parameter values does not cause re-initialization of ClientWithPrincipal", () => {
     rerender();
-    expect(client.withPrincipal).toHaveBeenCalledTimes(3);
+
+    expect(client.withPrincipal).not.toHaveBeenCalled();
   });
 });

--- a/private/test/src/matrix-react/hooks.test.tsx
+++ b/private/test/src/matrix-react/hooks.test.tsx
@@ -7,7 +7,6 @@ import {
   afterAll,
   afterEach,
   beforeAll,
-  beforeEach,
   describe,
   expect,
   it,
@@ -138,10 +137,6 @@ function testCerbosHook<TParams>(
 
     afterEach(() => {
       cleanup();
-    });
-
-    beforeEach(() => {
-      vi.clearAllMocks();
     });
 
     function render(

--- a/private/test/vitest.config.mts
+++ b/private/test/vitest.config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    clearMocks: true,
     setupFiles: "src/setup.ts",
     testTimeout: 20000,
   },


### PR DESCRIPTION
There are some [misleading test failures in the Cerbos 0.41.0-prerelease tests](https://github.com/cerbos/cerbos-sdk-javascript/actions/runs/12744692646/job/35517168185#step:5:2788). They should be failing because the spy wasn't called, but they're failing with an argument mismatch instead (because the spy was called with different arguments in another test).

This PR enables the [`clearMocks`](https://vitest.dev/config/#clearmocks) setting in Vitest to automatically clear mock usage history between tests.