### PR TITLE
fix: Omit metadata from embedded `checkResources` responses if `includeMetadata` is `false`

### DIFF
--- a/packages/embedded/CHANGELOG.md
+++ b/packages/embedded/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Accept async callbacks for [`onLoad`](../../docs/embedded.options.onload.md) and [`onError`](../../docs/embedded.options.onerror.md) ([#1091](https://github.com/cerbos/cerbos-sdk-javascript/pull/1091))
 
+- Omit metadata from `checkResources` responses if [`includeMetadata`](../../docs/core.checkresourcesrequest.includemetadata.md) is `false` ([#1092](https://github.com/cerbos/cerbos-sdk-javascript/pull/1092))
+
 ## [0.9.2] - 2025-02-06
 
 ### Changed

--- a/packages/embedded/changelog.yaml
+++ b/packages/embedded/changelog.yaml
@@ -9,6 +9,9 @@ unreleased:
     - summary: Accept async callbacks for [`onLoad`](../../docs/embedded.options.onload.md) and [`onError`](../../docs/embedded.options.onerror.md)
       pull: 1091
 
+    - summary: Omit metadata from `checkResources` responses if [`includeMetadata`](../../docs/core.checkresourcesrequest.includemetadata.md) is `false`
+      pull: 1092
+
 releases:
   - version: 0.9.2
     date: 2025-02-06

--- a/packages/embedded/src/bundle.ts
+++ b/packages/embedded/src/bundle.ts
@@ -162,6 +162,12 @@ export class Bundle {
           error,
         );
       }
+
+      if (response && !request.includeMeta) {
+        for (const result of response.results) {
+          result.meta = undefined;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Embedded PDPs unconditionally include metadata in check responses for audit purposes, so this PR makes sure that we strip it if `includeMetadata` was not specified on the request.