### PR TITLE
feat: adding compression to grpc client config

### DIFF
--- a/packages/grpc/src/client.ts
+++ b/packages/grpc/src/client.ts
@@ -79,6 +79,21 @@ export class GRPC extends Client {
       "grpc.primary_user_agent": `${
         options.userAgent ? `${options.userAgent} ` : ""
       }${defaultUserAgent}`,
+      "grpc.default_compression_algorithm": `${
+        options.compressionAlgorithm ? `${options.compressionAlgorithm} ` : "0"
+      }`,
+      // GZIP compression
+      // 0 - No compression
+      // 1 - Compress with DEFLATE algorithm
+      // 2 - Compress with GZIP algorithm
+      // 3 - Stream compression with GZIP algorithm
+      "grpc.default_compression_level": `${
+        options.compressionLevel ? `${options.compressionLevel} ` : "0"
+      }`,
+      // 0 - None
+      // 1 - Low level
+      // 2 - Medium level
+      // 3 - High level
     });
 
     super(new Transport(client), options);


### PR DESCRIPTION
#### Description

<!-- Thank you for contributing Cerbos! Please describe the changes made in this PR here and provide any other useful information for reviewers. Make sure that you included some automated tests (e.g unit tests) to verify your changes.  If there is a requirement for user input for testing, please include the instructions as well. -->

We were running into an issue with the JS SDK where we were running into issues of our requests being too large. 
`gRPC error 8 (RESOURCE_EXHAUSTED): grpc: received message larger than max (5244114 vs. 41914304)`

Thanks to @charithe we temporarily increased the limit using the `server.advanced.grpc.maxRecvMsgSizeBytes` configuration in this [documentation](https://docs.cerbos.dev/cerbos/latest/configuration/#full-configuration).

However our desire is to instead use compression when transmitting over the wire. This PR adds the gRPC configuration options to the client creation in the JS SDK.

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [X] The PR title has the correct prefix 
- [ ] PR is linked to the corresponding issue
- [ ] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
