### PR TITLE
chore: Don't set `registry-url` to avoid introducing a spurious `NODE_AUTH_TOKEN`

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -27,7 +27,6 @@ runs:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version == '' && '.node-version' || '' }}
         package-manager-cache: false
-        registry-url: https://registry.npmjs.com
 
     - name: Set up pnpm
       uses: pnpm/action-setup@v3


### PR DESCRIPTION
https://github.com/actions/setup-node/blob/2028fbc5c25fe9cf00d9f06a71cc4710d4507903/src/authutil.ts#L54-L58