### PR TITLE
chore(ci): Use GitHub App token to create automated pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    types:
-      - opened
-      - ready_for_review
-      - reopened
-      - synchronize
 
   schedule:
     - cron: 0 1 * * 1-5

--- a/.github/workflows/update-protos.yaml
+++ b/.github/workflows/update-protos.yaml
@@ -22,11 +22,19 @@ jobs:
       - name: Generate code
         run: pnpm run generate
 
+      - name: Generate bot token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.CERBOS_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.CERBOS_BOT_PRIVATE_KEY }}
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           branch: update-protos
-          draft: always-true
+          delete-branch: true
           reviewers: haines
           signoff: true
           sign-commits: true


### PR DESCRIPTION
GitHub Actions won't run workflows on PRs created by GitHub Actions. This PR circumvents the issue by using a GitHub App to create automated PRs.