### PR TITLE
chore: Migrate to `@connectrpc/validate`

### DIFF
--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Migrate to [@connectrpc/validate] ([#1294](https://github.com/cerbos/cerbos-sdk-javascript/pull/1294))
+
 - Bump dependency on [@connectrpc/connect] to 2.1.1 ([#1291](https://github.com/cerbos/cerbos-sdk-javascript/pull/1291))
 
 ## [0.2.4] - 2025-11-20
@@ -83,4 +85,5 @@
 [@cerbos/core]: ../core/README.md
 [@connectrpc/connect]: https://github.com/connectrpc/connect-es
 [@connectrpc/connect-node]: https://github.com/connectrpc/connect-es
+[@connectrpc/validate]: https://github.com/connectrpc/validate-es
 [opossum]: https://nodeshift.dev/opossum/

--- a/packages/hub/changelog.yaml
+++ b/packages/hub/changelog.yaml
@@ -1,6 +1,10 @@
 unreleased:
   type: patch
 
+  changed:
+    - summary: Migrate to [@connectrpc/validate]
+      pull: 1294
+
   bumped:
     "@connectrpc/connect":
       to: 2.1.1
@@ -112,6 +116,7 @@ references:
   "@cerbos/core": ../core/README.md
   "@connectrpc/connect": https://github.com/connectrpc/connect-es
   "@connectrpc/connect-node": https://github.com/connectrpc/connect-es
+  "@connectrpc/validate": https://github.com/connectrpc/validate-es
   opossum: https://nodeshift.dev/opossum/
 
 initialCommit: f477d2e7210284634461d85cb273d6a92e448ceb

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -51,10 +51,10 @@
     "@bufbuild/protobuf": "^2.10.1"
   },
   "dependencies": {
-    "@bufbuild/protovalidate": "^1.0.0",
     "@cerbos/core": "^0.25.2",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
+    "@connectrpc/validate": "^0.2.0",
     "opossum": "^9.0.0"
   },
   "devDependencies": {

--- a/packages/hub/src/interceptors/validation.ts
+++ b/packages/hub/src/interceptors/validation.ts
@@ -1,33 +1,3 @@
-import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
-import { createValidator } from "@bufbuild/protovalidate";
-import { Code, ConnectError } from "@connectrpc/connect";
+import { createValidateInterceptor } from "@connectrpc/validate";
 
-import { createInterceptor } from "./interceptor";
-
-const validator = createValidator();
-
-function validateRequest<Desc extends DescMessage>(
-  schema: Desc,
-  message: MessageShape<Desc>,
-): void {
-  const { kind, error } = validator.validate(schema, message);
-  if (kind === "invalid") {
-    throw new ConnectError(
-      "Invalid request",
-      Code.InvalidArgument,
-      undefined,
-      undefined,
-      error,
-    );
-  }
-}
-
-export const validationInterceptor = createInterceptor(
-  async (request, next) => {
-    if (!request.stream) {
-      validateRequest(request.method.input, request.message);
-    }
-
-    return await next(request);
-  },
-);
+export const validationInterceptor = createValidateInterceptor();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,9 +152,6 @@ importers:
       '@bufbuild/protobuf':
         specifier: ^2.10.1
         version: 2.10.1
-      '@bufbuild/protovalidate':
-        specifier: ^1.0.0
-        version: 1.0.0(@bufbuild/protobuf@2.10.1)
       '@cerbos/core':
         specifier: ^0.25.2
         version: link:../core
@@ -164,6 +161,9 @@ importers:
       '@connectrpc/connect-node':
         specifier: ^2.1.1
         version: 2.1.1(@bufbuild/protobuf@2.10.1)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.1))
+      '@connectrpc/validate':
+        specifier: ^0.2.0
+        version: 0.2.0(@bufbuild/protobuf@2.10.1)(@bufbuild/protovalidate@1.0.0(@bufbuild/protobuf@2.10.1))(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.1))
       opossum:
         specifier: ^9.0.0
         version: 9.0.0
@@ -543,6 +543,13 @@ packages:
     resolution: {integrity: sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.7.0
+
+  '@connectrpc/validate@0.2.0':
+    resolution: {integrity: sha512-u1hdyt1WaFkKpuT/3J2wYlCjYLkYHMZamoatgxTIsV5Q8H9fO2px3zecmb0Q47YDjkZqnX6z0PAEstK+dNYiEQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.9.0
+      '@bufbuild/protovalidate': ^1.0.0
+      '@connectrpc/connect': ^2.0.3
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -3367,6 +3374,12 @@ snapshots:
   '@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.1)':
     dependencies:
       '@bufbuild/protobuf': 2.10.1
+
+  '@connectrpc/validate@0.2.0(@bufbuild/protobuf@2.10.1)(@bufbuild/protovalidate@1.0.0(@bufbuild/protobuf@2.10.1))(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.10.1))':
+    dependencies:
+      '@bufbuild/protobuf': 2.10.1
+      '@bufbuild/protovalidate': 1.0.0(@bufbuild/protobuf@2.10.1)
+      '@connectrpc/connect': 2.1.1(@bufbuild/protobuf@2.10.1)
 
   '@csstools/color-helpers@5.1.0': {}
 

--- a/private/test/src/matrix-hub/validation.test.ts
+++ b/private/test/src/matrix-hub/validation.test.ts
@@ -25,7 +25,7 @@ describe("request validation", () => {
       expect(error).toBeInstanceOf(NotOK);
       expect(error).toMatchObject({
         code: Status.INVALID_ARGUMENT,
-        details: "Invalid request",
+        details: "store_id: value length must be 12 characters [string.len]",
       });
     }
   });


### PR DESCRIPTION
The folks at Buf have [released a Protovalidate interceptor for Connect](https://github.com/connectrpc/validate-es) so we no longer need to implement this ourselves.