### PR TITLE
Make `DecisionLogEntryPlanResources.output` optional

### DIFF
--- a/docs/core.decisionlogentryplanresources.md
+++ b/docs/core.decisionlogentryplanresources.md
@@ -102,12 +102,12 @@ The method that was called.
 
 </td><td>
 
-[PlanResourcesOutput](./core.planresourcesoutput.md)
+[PlanResourcesOutput](./core.planresourcesoutput.md) \| undefined
 
 
 </td><td>
 
-The outputs from the `PlanResources` call.
+The output from the `PlanResources` call.
 
 
 </td></tr>

--- a/docs/core.decisionlogentryplanresources.output.md
+++ b/docs/core.decisionlogentryplanresources.output.md
@@ -4,10 +4,10 @@
 
 ## DecisionLogEntryPlanResources.output property
 
-The outputs from the `PlanResources` call.
+The output from the `PlanResources` call.
 
 **Signature:**
 
 ```typescript
-output: PlanResourcesOutput;
+output: PlanResourcesOutput | undefined;
 ```

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - [`PolicySourceHubEmbeddedBundle`](../../docs/core.policysourcehubembeddedbundle.md) type ([#1310](https://github.com/cerbos/cerbos-sdk-javascript/pull/1310))
 
+### Changed
+
+- Make [`DecisionLogEntryPlanResources.output`](../../docs/core.decisionlogentryplanresources.output.md) optional ([#1311](https://github.com/cerbos/cerbos-sdk-javascript/pull/1311))
+
+  If an error was encountered while evaluating the `PlanResources` call, there may be no output.
+
 ## [0.25.2] - 2025-11-20
 
 ### Changed

--- a/packages/core/changelog.yaml
+++ b/packages/core/changelog.yaml
@@ -5,6 +5,11 @@ unreleased:
     - summary: "[`PolicySourceHubEmbeddedBundle`](../../docs/core.policysourcehubembeddedbundle.md) type"
       pull: 1310
 
+  changed:
+    - summary: Make [`DecisionLogEntryPlanResources.output`](../../docs/core.decisionlogentryplanresources.output.md) optional
+      details: If an error was encountered while evaluating the `PlanResources` call, there may be no output.
+      pull: 1311
+
 releases:
   - version: 0.25.2
     date: 2025-11-20

--- a/packages/core/src/convert/fromProtobuf.ts
+++ b/packages/core/src/convert/fromProtobuf.ts
@@ -589,12 +589,11 @@ function decisionLogEntryPlanResourcesFromProtobuf({
   error,
 }: DecisionLogEntry_PlanResources): DecisionLogEntryPlanResources {
   requireField("DecisionLogEntry.PlanResources.input", input);
-  requireField("DecisionLogEntry.PlanResources.output", output);
 
   return {
     name: "PlanResources",
     input: planResourcesInputFromProtobuf(input),
-    output: planResourcesOutputFromProtobuf(output),
+    output: output && planResourcesOutputFromProtobuf(output),
     error: error || undefined,
   };
 }

--- a/packages/core/src/types/external/DecisionLogEntryMethod.ts
+++ b/packages/core/src/types/external/DecisionLogEntryMethod.ts
@@ -67,9 +67,9 @@ export interface DecisionLogEntryPlanResources {
   input: PlanResourcesInput;
 
   /**
-   * The outputs from the `PlanResources` call.
+   * The output from the `PlanResources` call.
    */
-  output: PlanResourcesOutput;
+  output: PlanResourcesOutput | undefined;
 
   /**
    * The error (if any) encountered while evaluating the `PlanResources` call.


### PR DESCRIPTION
If an error was encountered while evaluating the `PlanResources` call, there may be no output.