### PR TITLE
Use shared Renovate config preset

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ ignoredBuiltDependencies:
 
 linkWorkspacePackages: true
 
-minimumReleaseAge: 4320 # 3 days
+minimumReleaseAge: 7200 # 5 days
 minimumReleaseAgeExclude:
   - "@cerbos/*"
   - react

--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "configMigration": true,
-  "extends": [
-    ":dependencyDashboard",
-    ":gitSignOff",
-    ":prConcurrentLimitNone",
-    ":semanticCommitsDisabled",
-    "helpers:pinGitHubActionDigests",
-    "schedule:weekly",
-    "workarounds:all"
-  ],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
-  "minimumReleaseAge": "3 days",
+  "extends": ["github>cerbos/renovate"],
   "packageRules": [
     {
       "matchDepTypes": ["dependencies", "peerDependencies"],
@@ -84,6 +71,5 @@
       "enabled": false
     }
   ],
-  "postUpdateOptions": ["pnpmDedupe"],
   "reviewers": ["haines"]
 }


### PR DESCRIPTION
This PR updates the Renovate config to use [our shared preset](https://github.com/cerbos/renovate/blob/main/default.json).