### PR TITLE
Fix link checking

### DIFF
--- a/scripts/check-links
+++ b/scripts/check-links
@@ -3,10 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-excludes=(
-  --exclude https://www.npmjs.com/
-  --exclude https://opentelemetry.io/
-)
+excludes=()
 
 case "${GITHUB_HEAD_REF:-}" in
   "prepare-release" | "prepare-releases")
@@ -22,15 +19,8 @@ check() {
     --rm \
     --user "${uid}:${gid}" \
     lychee \
+    --config /input/scripts/lychee.toml \
     "${excludes[@]}" \
-    --cache \
-    --cache-exclude-status 400.. \
-    --format detailed \
-    --include-fragments \
-    --max-concurrency 8 \
-    --max-cache-age 3d \
-    --remap "^https://cerbos\.github\.io/cerbos-sdk-javascript/ file:///input/docs/" \
-    --verbose \
     "$@" \
     2> >(grep -v -E "Skipping fragment check for [^ ]+ within a plaintext file")
 }

--- a/scripts/lychee.toml
+++ b/scripts/lychee.toml
@@ -1,0 +1,23 @@
+format = "detailed"
+verbose = "debug"
+
+cache = true
+cache_exclude_status = "400.."
+max_cache_age = "3d"
+
+max_concurrency = 8
+
+include_fragments = true
+
+exclude = [
+  "https://www.npmjs.com/",
+  "https://opentelemetry.io/",
+]
+
+remap = [
+  '^https://cerbos\.github\.io/cerbos-sdk-javascript/ file:///input/docs/',
+]
+
+# Slack returns 403 to unsupported browsers
+[hosts."go.cerbos.io".headers]
+"User-Agent" = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"


### PR DESCRIPTION
Slack has started returning 403 to unsupported browsers, which means that link checking fails after redirecting from https://go.cerbos.io/slack.

This PR overrides the user agent when checking that link to spoof a real browser.