### PR TITLE
Further policy source updates for Cerbos 0.52

### DIFF
--- a/.github/actions/lint/action.yaml
+++ b/.github/actions/lint/action.yaml
@@ -45,6 +45,7 @@ runs:
       run: pnpm run docs
 
     - name: Generate bot token
+      if: inputs.github-app-client-id != ''
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: generate-token
       continue-on-error: true

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
-No notable changes.
+### Added
+
+- Cerbos v0.52 updates ([#1437](https://github.com/cerbos/cerbos-sdk-javascript/pull/1437))
+  - `cerbos.audit.v1.PolicySource.Git.hash`
+  - `cerbos.audit.v1.PolicySource.Hub.LocalBundle.bundleId`
+  - `cerbos.audit.v1.PolicySource.Hub.RemoteBundle`
 
 ## [0.6.0] - 2026-02-03
 

--- a/packages/api/changelog.yaml
+++ b/packages/api/changelog.yaml
@@ -1,3 +1,14 @@
+unreleased:
+  type: minor
+
+  added:
+    - summary: Cerbos v0.52 updates
+      details: |-
+        - `cerbos.audit.v1.PolicySource.Git.hash`
+        - `cerbos.audit.v1.PolicySource.Hub.LocalBundle.bundleId`
+        - `cerbos.audit.v1.PolicySource.Hub.RemoteBundle`
+      pull: 1437
+
 releases:
   - version: 0.6.0
     date: 2026-02-03

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-No notable changes.
+### Added
+
+- Further policy source updates for Cerbos 0.52 ([#1437](https://github.com/cerbos/cerbos-sdk-javascript/pull/1437))
+  - [`LocalBundle.bundleId`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.LocalBundle.html#bundleid)
+  - [`PolicySourceGit.hash`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.PolicySourceGit.html#hash)
 
 ## [0.29.0] - 2026-04-28
 

--- a/packages/core/changelog.yaml
+++ b/packages/core/changelog.yaml
@@ -1,3 +1,13 @@
+unreleased:
+  type: minor
+
+  added:
+    - summary: Further policy source updates for Cerbos 0.52
+      details: |-
+        - [`LocalBundle.bundleId`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.LocalBundle.html#bundleid)
+        - [`PolicySourceGit.hash`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.PolicySourceGit.html#hash)
+      pull: 1437
+
 releases:
   - version: 0.29.0
     date: 2026-04-28

--- a/packages/core/src/convert/fromProtobuf.ts
+++ b/packages/core/src/convert/fromProtobuf.ts
@@ -390,12 +390,14 @@ function policySourceGitFromProtobuf({
   repositoryUrl,
   branch,
   subdirectory,
+  hash,
 }: PolicySource_Git): PolicySourceGit {
   return {
     kind: "git",
     repositoryUrl,
     branch,
     subdirectory,
+    hash,
   };
 }
 
@@ -474,8 +476,12 @@ function embeddedBundleFromProtobuf({
 
 function localBundleFromProtobuf({
   path,
+  bundleId,
 }: PolicySource_Hub_LocalBundle): LocalBundle {
-  return { path };
+  return {
+    path,
+    bundleId,
+  };
 }
 
 function remoteBundleFromProtobuf({

--- a/packages/core/src/types/external/LocalBundle.ts
+++ b/packages/core/src/types/external/LocalBundle.ts
@@ -6,4 +6,12 @@ export interface LocalBundle {
    * The path to the local policy bundle file.
    */
   path: string;
+
+  /**
+   * The ID of the local policy bundle.
+   *
+   * @remarks
+   * Requires the Cerbos policy decision point server to be at least v0.52.
+   */
+  bundleId: string;
 }

--- a/packages/core/src/types/external/PolicySource.ts
+++ b/packages/core/src/types/external/PolicySource.ts
@@ -150,6 +150,14 @@ export interface PolicySourceGit {
    * Subdirectory within the repository from which policies were loaded.
    */
   subdirectory: string;
+
+  /**
+   * Hash of the commit from which policies were cloned.
+   *
+   * @remarks
+   * Requires the Cerbos policy decision point server to be at least v0.52.
+   */
+  hash: string;
 }
 
 /**

--- a/packages/embedded-client/changelog.yaml
+++ b/packages/embedded-client/changelog.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  type: patch
+
 releases:
   - version: 0.5.2
     date: 2026-04-28

--- a/packages/embedded-client/src/server.ts
+++ b/packages/embedded-client/src/server.ts
@@ -288,6 +288,9 @@ function auditPolicySource(policies: PolicySource): AuditPolicySource {
 
   return {
     kind: "hub",
-    localBundle: { path: "" },
+    localBundle: {
+      path: "",
+      bundleId: "",
+    },
   };
 }

--- a/packages/embedded/changelog.yaml
+++ b/packages/embedded/changelog.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  type: patch
+
 releases:
   - version: 0.15.2
     date: 2026-04-28

--- a/packages/files/changelog.yaml
+++ b/packages/files/changelog.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  type: patch
+
 releases:
   - version: 0.6.3
     date: 2026-04-28

--- a/packages/grpc/CHANGELOG.md
+++ b/packages/grpc/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-No notable changes.
+### Added
+
+- Further policy source updates for Cerbos 0.52 ([#1437](https://github.com/cerbos/cerbos-sdk-javascript/pull/1437))
+  - [`LocalBundle.bundleId`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.LocalBundle.html#bundleid)
+  - [`PolicySourceGit.hash`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.PolicySourceGit.html#hash)
 
 ## [0.26.0] - 2026-04-28
 

--- a/packages/grpc/changelog.yaml
+++ b/packages/grpc/changelog.yaml
@@ -1,3 +1,13 @@
+unreleased:
+  type: minor
+
+  added:
+    - summary: Further policy source updates for Cerbos 0.52
+      details: |-
+        - [`LocalBundle.bundleId`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.LocalBundle.html#bundleid)
+        - [`PolicySourceGit.hash`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.PolicySourceGit.html#hash)
+      pull: 1437
+
 releases:
   - version: 0.26.0
     date: 2026-04-28

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-No notable changes.
+### Added
+
+- Further policy source updates for Cerbos 0.52 ([#1437](https://github.com/cerbos/cerbos-sdk-javascript/pull/1437))
+  - [`LocalBundle.bundleId`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.LocalBundle.html#bundleid)
+  - [`PolicySourceGit.hash`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.PolicySourceGit.html#hash)
 
 ## [0.27.0] - 2026-04-28
 

--- a/packages/http/changelog.yaml
+++ b/packages/http/changelog.yaml
@@ -1,3 +1,13 @@
+unreleased:
+  type: minor
+
+  added:
+    - summary: Further policy source updates for Cerbos 0.52
+      details: |-
+        - [`LocalBundle.bundleId`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.LocalBundle.html#bundleid)
+        - [`PolicySourceGit.hash`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.PolicySourceGit.html#hash)
+      pull: 1437
+
 releases:
   - version: 0.27.0
     date: 2026-04-28

--- a/packages/hub/changelog.yaml
+++ b/packages/hub/changelog.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  type: patch
+
 releases:
   - version: 0.5.4
     date: 2026-04-28

--- a/packages/opentelemetry/changelog.yaml
+++ b/packages/opentelemetry/changelog.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  type: patch
+
 releases:
   - version: 0.10.2
     date: 2026-04-28

--- a/packages/react/changelog.yaml
+++ b/packages/react/changelog.yaml
@@ -1,3 +1,6 @@
+unreleased:
+  type: patch
+
 releases:
   - version: 0.3.4
     date: 2026-04-28

--- a/private/test/src/matrix-node/embedded/v2/client.test.ts
+++ b/private/test/src/matrix-node/embedded/v2/client.test.ts
@@ -85,7 +85,13 @@ describe("Embedded", () => {
           ),
         bundleId: localBundleId,
         storeId: "NKFD70XLV8I5",
-        policySource: { kind: "hub", localBundle: { path: "" } },
+        policySource: {
+          kind: "hub",
+          localBundle: {
+            path: "",
+            bundleId: "",
+          },
+        },
       },
     ];
 


### PR DESCRIPTION
I should've marked `@cerbos/api` as having unreleased changes in #1418. As it stands, the latest releases have types for `PolicySourceHubRemoteBundle` but won't actually be able to handle audit log entries with that set because they still depend on the old `@cerbos/api` release.

Also handles `cerbos.audit.v1.PolicySource.Git.hash` and `cerbos.audit.v1.PolicySource.Hub.LocalBundle.bundleId`, which I missed in #1418.