### PR TITLE
Support `exactOptionalPropertyTypes`

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -19,6 +19,9 @@ export type { ErrorDetails } from "./errors/response.js";
 export { AbstractErrorResponse } from "./errors/response.js";
 export * from "./transport.js";
 
+/** @inline */
+export type Optional<T> = { [K in keyof T]?: T[K] | undefined };
+
 /** @internal */
 export function cancelBody(response: Response): void {
   response.body?.cancel().catch(() => {

--- a/packages/embedded-client/CHANGELOG.md
+++ b/packages/embedded-client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) by typing optional properties with explicit `| undefined` ([#1442](https://github.com/cerbos/cerbos-sdk-javascript/pull/1442))
+
 ### Changed
 
 - Bump dependency on [@bufbuild/protobuf] to 2.12.0 ([#1441](https://github.com/cerbos/cerbos-sdk-javascript/pull/1441))

--- a/packages/embedded-client/changelog.yaml
+++ b/packages/embedded-client/changelog.yaml
@@ -1,6 +1,10 @@
 unreleased:
   type: patch
 
+  added:
+    - summary: Support for [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) by typing optional properties with explicit `| undefined`
+      pull: 1442
+
   bumped:
     "@bufbuild/protobuf":
       to: 2.12.0

--- a/packages/embedded-client/src/loader.ts
+++ b/packages/embedded-client/src/loader.ts
@@ -24,7 +24,7 @@ export class PolicyLoader {
   public readonly scopes: string[];
 
   private readonly activateOnLoad: boolean;
-  private readonly interval?: number;
+  private readonly interval?: number | undefined;
   private readonly onUpdate?: PolicyLoaderOptions["onUpdate"];
   private readonly servers: Server[] = [];
   private readonly client: HubClient<typeof BundleService>;
@@ -32,7 +32,7 @@ export class PolicyLoader {
   private activations = 0;
   private initialLoad?: Promise<void>;
   private activeBundle?: BundleValid;
-  private pendingBundle?: BundleValid;
+  private pendingBundle?: BundleValid | undefined;
   private timeout?: NodeJS.Timeout;
 
   /**

--- a/packages/embedded-client/src/options.ts
+++ b/packages/embedded-client/src/options.ts
@@ -6,6 +6,7 @@ import type {
   NotOK,
   Value,
 } from "@cerbos/core";
+import type { Optional } from "@cerbos/core/~internal";
 import type { ClientOptions as HubClientOptions } from "@cerbos/hub";
 
 import type { PolicyLoader } from "./loader.js";
@@ -79,7 +80,7 @@ export interface Options extends Pick<
    *
    * @defaultValue `SchemaEnforcement.NONE`
    */
-  schemaEnforcement?: SchemaEnforcement;
+  schemaEnforcement?: SchemaEnforcement | undefined;
 }
 
 /**
@@ -121,7 +122,7 @@ export type PolicySource =
 /**
  * Options for creating a {@link PolicyLoader}.
  */
-export interface PolicyLoaderOptions extends Partial<HubClientOptions> {
+export interface PolicyLoaderOptions extends Optional<HubClientOptions> {
   /**
    * ID of the {@link https://docs.cerbos.dev/cerbos-hub/deployments-epdp-rules | policy bundling rule}.
    */
@@ -132,7 +133,7 @@ export interface PolicyLoaderOptions extends Partial<HubClientOptions> {
    *
    * @defaultValue (all scopes)
    */
-  scopes?: string[];
+  scopes?: string[] | undefined;
 
   /**
    * Whether to activate updated policy bundles as soon as they are downloaded.
@@ -143,7 +144,7 @@ export interface PolicyLoaderOptions extends Partial<HubClientOptions> {
    *
    * @defaultValue `true`
    */
-  activateOnLoad?: boolean;
+  activateOnLoad?: boolean | undefined;
 
   /**
    * The delay (in seconds) between successive requests to check for policy bundle updates.
@@ -155,7 +156,7 @@ export interface PolicyLoaderOptions extends Partial<HubClientOptions> {
    *
    * @defaultValue `60` (1 minute)
    */
-  interval?: number;
+  interval?: number | undefined;
 
   /**
    * A callback to invoke when a policy bundle update has finished.

--- a/packages/embedded/CHANGELOG.md
+++ b/packages/embedded/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) by typing optional properties with explicit `| undefined` ([#1442](https://github.com/cerbos/cerbos-sdk-javascript/pull/1442))
+
 ### Changed
 
 - Bump dependency on [@bufbuild/protobuf] to 2.12.0 ([#1441](https://github.com/cerbos/cerbos-sdk-javascript/pull/1441))

--- a/packages/embedded/changelog.yaml
+++ b/packages/embedded/changelog.yaml
@@ -1,6 +1,10 @@
 unreleased:
   type: patch
 
+  added:
+    - summary: Support for [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) by typing optional properties with explicit `| undefined`
+      pull: 1442
+
   bumped:
     "@bufbuild/protobuf":
       to: 2.12.0

--- a/packages/embedded/src/loader.ts
+++ b/packages/embedded/src/loader.ts
@@ -372,7 +372,7 @@ export interface AutoUpdateOptions extends Options {
    *
    * @defaultValue `true`
    */
-  activateOnLoad?: boolean;
+  activateOnLoad?: boolean | undefined;
 
   /**
    * The delay (in milliseconds) between successive requests to check for new embedded policy decision point bundles.
@@ -382,7 +382,7 @@ export interface AutoUpdateOptions extends Options {
    *
    * @defaultValue `60_000` (1 minute)
    */
-  interval?: number;
+  interval?: number | undefined;
 }
 
 /**

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) by typing optional properties with explicit `| undefined` ([#1442](https://github.com/cerbos/cerbos-sdk-javascript/pull/1442))
+
 ### Changed
 
 - Bump dependency on [@bufbuild/protobuf] to 2.12.0 ([#1441](https://github.com/cerbos/cerbos-sdk-javascript/pull/1441))

--- a/packages/hub/changelog.yaml
+++ b/packages/hub/changelog.yaml
@@ -1,6 +1,10 @@
 unreleased:
   type: patch
 
+  added:
+    - summary: Support for [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) by typing optional properties with explicit `| undefined`
+      pull: 1442
+
   bumped:
     "@bufbuild/protobuf":
       to: 2.12.0

--- a/packages/hub/src/client.ts
+++ b/packages/hub/src/client.ts
@@ -10,6 +10,7 @@ import type { CallOptions, Interceptor, Transport } from "@connectrpc/connect";
 import { makeAnyClient } from "@connectrpc/connect";
 
 import type { Options, RequestOptions } from "@cerbos/core";
+import type { Optional } from "@cerbos/core/~internal";
 import { createTransport } from "@cerbos/hub/~internal/transport";
 
 import type { Credentials } from "./credentials.js";
@@ -37,8 +38,8 @@ export interface ClientOptions extends Pick<Options, "headers" | "userAgent"> {
   baseUrl?: string | undefined;
 }
 
-interface InternalClientOptions extends Partial<ClientOptions> {
-  createError?: (error: unknown) => Error;
+interface InternalClientOptions extends Optional<ClientOptions> {
+  createError?: ((error: unknown) => Error) | undefined;
 }
 
 // Adapted from https://github.com/connectrpc/connect-es/blob/v2.0.2/packages/connect/src/promise-client.ts#L39-L46

--- a/packages/hub/src/types/ModifyFilesRequest.ts
+++ b/packages/hub/src/types/ModifyFilesRequest.ts
@@ -35,5 +35,5 @@ export interface ModifyFilesRequest {
    *
    * @defaultValue `false`
    */
-  allowUnchanged?: boolean;
+  allowUnchanged?: boolean | undefined;
 }

--- a/packages/hub/src/types/ReplaceFilesRequest.ts
+++ b/packages/hub/src/types/ReplaceFilesRequest.ts
@@ -35,5 +35,5 @@ export interface ReplaceFilesRequest {
    *
    * @defaultValue `false`
    */
-  allowUnchanged?: boolean;
+  allowUnchanged?: boolean | undefined;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,6 @@
   "extends": ["@tsconfig/node20", "@tsconfig/strictest"],
   "compilerOptions": {
     "composite": true,
-    "exactOptionalPropertyTypes": false,
     "types": ["node"]
   }
 }


### PR DESCRIPTION
`exactOptionalPropertyTypes` is on by default in new TypeScript projects (using `tsc --init`), so it makes sense to re-enable it for our own code and ensure that our exported types are defined with `| undefined` for optional properties.