### PR TITLE
Add missing fields when deserializing role policies

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,13 +8,19 @@
 
   Requires a policy decision point server running Cerbos 0.54+.
 
-- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452))
+- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
   Requires a policy decision point server running Cerbos 0.54+.
 
-- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452))
+- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
   Requires a policy decision point server running Cerbos 0.54+.
+
+### Changed
+
+- Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition) ([#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
+
+  Previously, these fields could be set in an [`AddOrUpdatePoliciesRequest`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.AddOrUpdatePoliciesRequest.html), but were omitted from [`GetPoliciesResponse`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.GetPoliciesResponse.html), so round-tripping role policies to and from the policy decision point server was lossy.
 
 ### Removed
 

--- a/packages/core/changelog.yaml
+++ b/packages/core/changelog.yaml
@@ -8,11 +8,16 @@ unreleased:
 
     - summary: "[`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties"
       details: Requires a policy decision point server running Cerbos 0.54+.
-      pull: 1452
+      pulls: [1452, 1456]
 
     - summary: "[`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties"
       details: Requires a policy decision point server running Cerbos 0.54+.
-      pull: 1452
+      pulls: [1452, 1456]
+
+  changed:
+    - summary: Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition)
+      details: Previously, these fields could be set in an [`AddOrUpdatePoliciesRequest`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.AddOrUpdatePoliciesRequest.html), but were omitted from [`GetPoliciesResponse`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.GetPoliciesResponse.html), so round-tripping role policies to and from the policy decision point server was lossy.
+      pull: 1456
 
   removed:
     - summary: Support for Node.js 20, which is now [end-of-life][nodejs-eol]

--- a/packages/core/src/convert/fromProtobuf.ts
+++ b/packages/core/src/convert/fromProtobuf.ts
@@ -1172,8 +1172,11 @@ function resourceRuleFromProtobuf({
 
 function rolePolicyFromProtobuf({
   policyType,
+  version,
   parentRoles,
   scope,
+  constants,
+  variables,
   rules,
 }: RolePolicyProtobuf): RolePolicy {
   requireOneOf("RolePolicy.policyType", policyType, "role");
@@ -1181,8 +1184,11 @@ function rolePolicyFromProtobuf({
   return {
     rolePolicy: {
       role: policyType.value,
+      version,
       parentRoles: parentRoles,
       scope,
+      constants: constants && constantsFromProtobuf(constants),
+      variables: variables && variablesFromProtobuf(variables),
       rules: rules.map(roleRuleFromProtobuf),
     },
   };
@@ -1191,10 +1197,16 @@ function rolePolicyFromProtobuf({
 function roleRuleFromProtobuf({
   resource,
   allowActions,
+  condition,
+  name,
+  output,
 }: RoleRuleProtobuf): RoleRule {
   return {
     resource,
     allowActions,
+    condition: condition && conditionFromProtobuf(condition),
+    name,
+    output: output && outputFromProtobuf(output),
   };
 }
 

--- a/packages/files/CHANGELOG.md
+++ b/packages/files/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
+
+- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
+
 ### Changed
+
+- Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition) ([#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
 - Bump dependency on [yaml] to 2.9.0 ([#1450](https://github.com/cerbos/cerbos-sdk-javascript/pull/1450), [#1453](https://github.com/cerbos/cerbos-sdk-javascript/pull/1453))
 

--- a/packages/files/changelog.yaml
+++ b/packages/files/changelog.yaml
@@ -1,6 +1,17 @@
 unreleased:
   type: minor
 
+  added:
+    - summary: "[`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties"
+      pulls: [1452, 1456]
+
+    - summary: "[`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties"
+      pulls: [1452, 1456]
+
+  changed:
+    - summary: Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition)
+      pull: 1456
+
   bumped:
     yaml:
       to: 2.9.0

--- a/packages/grpc/CHANGELOG.md
+++ b/packages/grpc/CHANGELOG.md
@@ -8,13 +8,19 @@
 
   Requires a policy decision point server running Cerbos 0.54+.
 
-- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452))
+- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
   Requires a policy decision point server running Cerbos 0.54+.
 
-- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452))
+- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
   Requires a policy decision point server running Cerbos 0.54+.
+
+### Changed
+
+- Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition) ([#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
+
+  Previously, these fields could be set in an [`AddOrUpdatePoliciesRequest`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.AddOrUpdatePoliciesRequest.html), but were omitted from [`GetPoliciesResponse`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.GetPoliciesResponse.html), so round-tripping role policies to and from the policy decision point server was lossy.
 
 ### Removed
 

--- a/packages/grpc/changelog.yaml
+++ b/packages/grpc/changelog.yaml
@@ -8,11 +8,16 @@ unreleased:
 
     - summary: "[`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties"
       details: Requires a policy decision point server running Cerbos 0.54+.
-      pull: 1452
+      pulls: [1452, 1456]
 
     - summary: "[`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties"
       details: Requires a policy decision point server running Cerbos 0.54+.
-      pull: 1452
+      pulls: [1452, 1456]
+
+  changed:
+    - summary: Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition)
+      details: Previously, these fields could be set in an [`AddOrUpdatePoliciesRequest`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.AddOrUpdatePoliciesRequest.html), but were omitted from [`GetPoliciesResponse`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.GetPoliciesResponse.html), so round-tripping role policies to and from the policy decision point server was lossy.
+      pull: 1456
 
   removed:
     - summary: Support for Node.js 20, which is now [end-of-life][nodejs-eol]

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -8,13 +8,19 @@
 
   Requires a policy decision point server running Cerbos 0.54+.
 
-- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452))
+- [`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
   Requires a policy decision point server running Cerbos 0.54+.
 
-- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452))
+- [`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties ([#1452](https://github.com/cerbos/cerbos-sdk-javascript/pull/1452), [#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
 
   Requires a policy decision point server running Cerbos 0.54+.
+
+### Changed
+
+- Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition) ([#1456](https://github.com/cerbos/cerbos-sdk-javascript/pull/1456))
+
+  Previously, these fields could be set in an [`AddOrUpdatePoliciesRequest`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.AddOrUpdatePoliciesRequest.html), but were omitted from [`GetPoliciesResponse`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.GetPoliciesResponse.html), so round-tripping role policies to and from the policy decision point server was lossy.
 
 ### Removed
 

--- a/packages/http/changelog.yaml
+++ b/packages/http/changelog.yaml
@@ -8,11 +8,16 @@ unreleased:
 
     - summary: "[`RolePolicyBody.constants`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#constants) and [`variables`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#variables) properties"
       details: Requires a policy decision point server running Cerbos 0.54+.
-      pull: 1452
+      pulls: [1452, 1456]
 
     - summary: "[`RoleRule.name`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#name) and [`output`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#output) properties"
       details: Requires a policy decision point server running Cerbos 0.54+.
-      pull: 1452
+      pulls: [1452, 1456]
+
+  changed:
+    - summary: Deserialize [`RolePolicyBody.version`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RolePolicyBody.html#version) and [`RoleRule.condition`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.RoleRule.html#condition)
+      details: Previously, these fields could be set in an [`AddOrUpdatePoliciesRequest`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.AddOrUpdatePoliciesRequest.html), but were omitted from [`GetPoliciesResponse`](https://cerbos.github.io/cerbos-sdk-javascript/interfaces/_cerbos_core.GetPoliciesResponse.html), so round-tripping role policies to and from the policy decision point server was lossy.
+      pull: 1456
 
   removed:
     - summary: Support for Node.js 20, which is now [end-of-life][nodejs-eol]


### PR DESCRIPTION
This PR fixes deserialization of role policy fields added in #1076, #1344, and #1452.